### PR TITLE
Add preact framework entry for addon docs

### DIFF
--- a/addons/docs/src/frameworks/preact/config.ts
+++ b/addons/docs/src/frameworks/preact/config.ts
@@ -1,0 +1,18 @@
+import { PartialStoryFn } from '@storybook/csf';
+import { ReactFramework } from '@storybook/react';
+
+import { extractArgTypes } from './extractArgTypes';
+import { extractComponentDescription } from '../../lib/docgen';
+import { jsxDecorator } from './jsxDecorator';
+
+export const parameters = {
+  docs: {
+    inlineStories: true,
+    // NOTE: that the result is a react element. Hooks support is provided by the outer code.
+    prepareForInline: (storyFn: PartialStoryFn<ReactFramework>) => storyFn(),
+    extractArgTypes,
+    extractComponentDescription,
+  },
+};
+
+export const decorators = [jsxDecorator];

--- a/addons/docs/src/frameworks/preact/extractArgTypes.ts
+++ b/addons/docs/src/frameworks/preact/extractArgTypes.ts
@@ -1,0 +1,36 @@
+import { StrictArgTypes } from '@storybook/csf';
+import { PropDef, ArgTypesExtractor } from '../../lib/docgen';
+import { extractProps } from './extractProps';
+
+export const extractArgTypes: ArgTypesExtractor = (component) => {
+  if (component) {
+    const { rows } = extractProps(component);
+    if (rows) {
+      return rows.reduce((acc: StrictArgTypes, row: PropDef) => {
+        const {
+          name,
+          description,
+          type,
+          sbType,
+          defaultValue: defaultSummary,
+          jsDocTags,
+          required,
+        } = row;
+
+        acc[name] = {
+          name,
+          description,
+          type: { required, ...sbType },
+          table: {
+            type,
+            jsDocTags,
+            defaultValue: defaultSummary,
+          },
+        };
+        return acc;
+      }, {});
+    }
+  }
+
+  return null;
+};

--- a/addons/docs/src/frameworks/preact/extractProps.ts
+++ b/addons/docs/src/frameworks/preact/extractProps.ts
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import {
+  PropDef,
+  hasDocgen,
+  extractComponentProps,
+  PropsExtractor,
+  TypeSystem,
+} from '../../lib/docgen';
+import { Component } from '../../blocks/types';
+import { enhancePropTypesProps } from './propTypes/handleProp';
+import { enhanceTypeScriptProps } from './typeScript/handleProp';
+import { isMemo } from './lib';
+
+export interface PropDefMap {
+  [p: string]: PropDef;
+}
+
+const propTypesMap = new Map();
+
+Object.keys(PropTypes).forEach((typeName) => {
+  // @ts-ignore
+  const type = PropTypes[typeName];
+
+  propTypesMap.set(type, typeName);
+  propTypesMap.set(type.isRequired, typeName);
+});
+
+function getPropDefs(component: Component, section: string): PropDef[] {
+  let processedComponent = component;
+
+  // eslint-disable-next-line react/forbid-foreign-prop-types
+  if (!hasDocgen(component) && !component.propTypes && isMemo(component)) {
+    processedComponent = component.type;
+  }
+
+  const extractedProps = extractComponentProps(processedComponent, section);
+  if (extractedProps.length === 0) {
+    return [];
+  }
+
+  switch (extractedProps[0].typeSystem) {
+    case TypeSystem.JAVASCRIPT:
+      return enhancePropTypesProps(extractedProps, component);
+    case TypeSystem.TYPESCRIPT:
+      return enhanceTypeScriptProps(extractedProps);
+    default:
+      return extractedProps.map((x) => x.propDef);
+  }
+}
+
+export const extractProps: PropsExtractor = (component) => ({
+  rows: getPropDefs(component, 'props'),
+});

--- a/addons/docs/src/frameworks/preact/jsxDecorator.test.tsx
+++ b/addons/docs/src/frameworks/preact/jsxDecorator.test.tsx
@@ -1,0 +1,287 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { addons, StoryContext, useEffect } from '@storybook/addons';
+import { renderJsx, jsxDecorator } from './jsxDecorator';
+import { SNIPPET_RENDERED } from '../../shared';
+
+jest.mock('@storybook/addons');
+const mockedAddons = addons as jest.Mocked<typeof addons>;
+const mockedUseEffect = useEffect as jest.Mocked<typeof useEffect>;
+
+expect.addSnapshotSerializer({
+  print: (val: any) => val,
+  test: (val) => typeof val === 'string',
+});
+
+describe('renderJsx', () => {
+  it('basic', () => {
+    expect(renderJsx(<div>hello</div>, {})).toMatchInlineSnapshot(`
+      <div>
+        hello
+      </div>
+    `);
+  });
+  it('functions', () => {
+    // eslint-disable-next-line no-console
+    const onClick = () => console.log('onClick');
+    expect(renderJsx(<div onClick={onClick}>hello</div>, {})).toMatchInlineSnapshot(`
+      <div onClick={() => {}}>
+        hello
+      </div>
+    `);
+  });
+  it('undefined values', () => {
+    expect(renderJsx(<div className={undefined}>hello</div>, {})).toMatchInlineSnapshot(`
+      <div>
+        hello
+      </div>
+    `);
+  });
+  it('null values', () => {
+    expect(renderJsx(<div className={null}>hello</div>, {})).toMatchInlineSnapshot(`
+      <div className={null}>
+        hello
+      </div>
+    `);
+  });
+  it('large objects', () => {
+    const obj = Array.from({ length: 20 }).reduce((acc, _, i) => {
+      acc[`key_${i}`] = `val_${i}`;
+      return acc;
+    }, {});
+    expect(renderJsx(<div data-val={obj} />, {})).toMatchInlineSnapshot(`
+      <div
+        data-val={{
+          key_0: 'val_0',
+          key_1: 'val_1',
+          key_10: 'val_10',
+          key_11: 'val_11',
+          key_12: 'val_12',
+          key_13: 'val_13',
+          key_14: 'val_14',
+          key_15: 'val_15',
+          key_16: 'val_16',
+          key_17: 'val_17',
+          key_18: 'val_18',
+          key_19: 'val_19',
+          key_2: 'val_2',
+          key_3: 'val_3',
+          key_4: 'val_4',
+          key_5: 'val_5',
+          key_6: 'val_6',
+          key_7: 'val_7',
+          key_8: 'val_8',
+          key_9: 'val_9'
+        }}
+       />
+    `);
+  });
+
+  it('long arrays', () => {
+    const arr = Array.from({ length: 20 }, (_, i) => `item ${i}`);
+    expect(renderJsx(<div data-val={arr} />, {})).toMatchInlineSnapshot(`
+      <div
+        data-val={[
+          'item 0',
+          'item 1',
+          'item 2',
+          'item 3',
+          'item 4',
+          'item 5',
+          'item 6',
+          'item 7',
+          'item 8',
+          'item 9',
+          'item 10',
+          'item 11',
+          'item 12',
+          'item 13',
+          'item 14',
+          'item 15',
+          'item 16',
+          'item 17',
+          'item 18',
+          'item 19'
+        ]}
+       />
+    `);
+  });
+
+  it('forwardRef component', () => {
+    const MyExoticComponent = React.forwardRef(function MyExoticComponent(props: any, _ref: any) {
+      return <div>{props.children}</div>;
+    });
+
+    expect(renderJsx(<MyExoticComponent>I'm forwardRef!</MyExoticComponent>, {}))
+      .toMatchInlineSnapshot(`
+        <MyExoticComponent>
+          I'm forwardRef!
+        </MyExoticComponent>
+      `);
+  });
+
+  it('memo component', () => {
+    const MyMemoComponent = React.memo(function MyMemoComponent(props: any) {
+      return <div>{props.children}</div>;
+    });
+
+    expect(renderJsx(<MyMemoComponent>I'm memo!</MyMemoComponent>, {})).toMatchInlineSnapshot(`
+      <MyMemoComponent>
+        I'm memo!
+      </MyMemoComponent>
+    `);
+  });
+
+  it('should not add default props to string if the prop value has not changed', () => {
+    const Container = ({ className, children }: { className: string; children: string }) => {
+      return <div className={className}>{children}</div>;
+    };
+
+    Container.propTypes = {
+      children: PropTypes.string.isRequired,
+      className: PropTypes.string,
+    };
+
+    Container.defaultProps = {
+      className: 'super-container',
+    };
+
+    expect(renderJsx(<Container>yo dude</Container>, {})).toMatchInlineSnapshot(`
+      <Container className="super-container">
+        yo dude
+      </Container>
+    `);
+  });
+});
+
+// @ts-ignore
+const makeContext = (name: string, parameters: any, args: any, extra?: object): StoryContext => ({
+  id: `jsx-test--${name}`,
+  kind: 'js-text',
+  name,
+  parameters,
+  args,
+  ...extra,
+});
+
+describe('jsxDecorator', () => {
+  let mockChannel: { on: jest.Mock; emit?: jest.Mock };
+  beforeEach(() => {
+    mockedAddons.getChannel.mockReset();
+    mockedUseEffect.mockImplementation((cb) => setTimeout(cb, 0));
+
+    mockChannel = { on: jest.fn(), emit: jest.fn() };
+    mockedAddons.getChannel.mockReturnValue(mockChannel as any);
+  });
+
+  it('should render dynamically for args stories', async () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const context = makeContext('args', { __isArgsStory: true }, {});
+    jsxDecorator(storyFn, context);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockChannel.emit).toHaveBeenCalledWith(
+      SNIPPET_RENDERED,
+      'jsx-test--args',
+      '<div>\n  args story\n</div>'
+    );
+  });
+
+  it('should not render decorators when provided excludeDecorators parameter', async () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const decoratedStoryFn = (args: any) => (
+      <div style={{ padding: 25, border: '3px solid red' }}>{storyFn(args)}</div>
+    );
+    const context = makeContext(
+      'args',
+      {
+        __isArgsStory: true,
+        docs: {
+          source: {
+            excludeDecorators: true,
+          },
+        },
+      },
+      {},
+      { originalStoryFn: storyFn }
+    );
+    jsxDecorator(decoratedStoryFn, context);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockChannel.emit).toHaveBeenCalledWith(
+      SNIPPET_RENDERED,
+      'jsx-test--args',
+      '<div>\n  args story\n</div>'
+    );
+  });
+
+  it('should skip dynamic rendering for no-args stories', async () => {
+    const storyFn = () => <div>classic story</div>;
+    const context = makeContext('classic', {}, {});
+    jsxDecorator(storyFn, context);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockChannel.emit).not.toHaveBeenCalled();
+  });
+
+  // This is deprecated, but still test it
+  it('allows the snippet output to be modified by onBeforeRender', async () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const onBeforeRender = (dom: string) => `<p>${dom}</p>`;
+    const jsx = { onBeforeRender };
+    const context = makeContext('args', { __isArgsStory: true, jsx }, {});
+    jsxDecorator(storyFn, context);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockChannel.emit).toHaveBeenCalledWith(
+      SNIPPET_RENDERED,
+      'jsx-test--args',
+      '<p><div>\n  args story\n</div></p>'
+    );
+  });
+
+  it('allows the snippet output to be modified by transformSource', async () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const transformSource = (dom: string) => `<p>${dom}</p>`;
+    const jsx = { transformSource };
+    const context = makeContext('args', { __isArgsStory: true, jsx }, {});
+    jsxDecorator(storyFn, context);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockChannel.emit).toHaveBeenCalledWith(
+      SNIPPET_RENDERED,
+      'jsx-test--args',
+      '<p><div>\n  args story\n</div></p>'
+    );
+  });
+
+  it('provides the story context to transformSource', () => {
+    const storyFn = (args: any) => <div>args story</div>;
+    const transformSource = jest.fn();
+    const jsx = { transformSource };
+    const context = makeContext('args', { __isArgsStory: true, jsx }, {});
+    jsxDecorator(storyFn, context);
+    expect(transformSource).toHaveBeenCalledWith('<div>\n  args story\n</div>', context);
+  });
+
+  it('renders MDX properly', async () => {
+    // FIXME: generate this from actual MDX
+    const mdxElement = {
+      type: { displayName: 'MDXCreateElement' },
+      props: {
+        mdxType: 'div',
+        originalType: 'div',
+        className: 'foo',
+      },
+    };
+
+    jsxDecorator(() => mdxElement, makeContext('mdx-args', { __isArgsStory: true }, {}));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockChannel.emit).toHaveBeenCalledWith(
+      SNIPPET_RENDERED,
+      'jsx-test--mdx-args',
+      '<div className="foo" />'
+    );
+  });
+});

--- a/addons/docs/src/frameworks/preact/jsxDecorator.tsx
+++ b/addons/docs/src/frameworks/preact/jsxDecorator.tsx
@@ -1,0 +1,212 @@
+import React, { createElement, ReactElement } from 'react';
+import reactElementToJSXString, { Options } from 'react-element-to-jsx-string';
+import dedent from 'ts-dedent';
+import deprecate from 'util-deprecate';
+
+import { addons, useEffect } from '@storybook/addons';
+import { StoryContext, ArgsStoryFn, PartialStoryFn } from '@storybook/csf';
+import { logger } from '@storybook/client-logger';
+import { ReactFramework } from '@storybook/react';
+
+import { SourceType, SNIPPET_RENDERED } from '../../shared';
+import { getDocgenSection } from '../../lib/docgen';
+import { isMemo, isForwardRef } from './lib';
+
+type JSXOptions = Options & {
+  /** How many wrappers to skip when rendering the jsx */
+  skip?: number;
+  /** Whether to show the function in the jsx tab */
+  showFunctions?: boolean;
+  /** Whether to format HTML or Vue markup */
+  enableBeautify?: boolean;
+  /** Override the display name used for a component */
+  displayName?: string | Options['displayName'];
+  /** Deprecated: A function ran after the story is rendered */
+  onBeforeRender?(dom: string): string;
+  /** A function ran after a story is rendered (prefer this over `onBeforeRender`) */
+  transformSource?(dom: string, context?: StoryContext<ReactFramework>): string;
+};
+
+/** Run the user supplied onBeforeRender function if it exists */
+const applyBeforeRender = (domString: string, options: JSXOptions) => {
+  if (typeof options.onBeforeRender !== 'function') {
+    return domString;
+  }
+
+  const deprecatedOnBeforeRender = deprecate(
+    options.onBeforeRender,
+    dedent`
+      StoryFn.parameters.jsx.onBeforeRender was deprecated.
+      Prefer StoryFn.parameters.jsx.transformSource instead.
+      See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-onbeforerender for details.
+    `
+  );
+
+  return deprecatedOnBeforeRender(domString);
+};
+
+/** Run the user supplied transformSource function if it exists */
+const applyTransformSource = (
+  domString: string,
+  options: JSXOptions,
+  context?: StoryContext<ReactFramework>
+) => {
+  if (typeof options.transformSource !== 'function') {
+    return domString;
+  }
+
+  return options.transformSource(domString, context);
+};
+
+/** Apply the users parameters and render the jsx for a story */
+export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
+  if (typeof code === 'undefined') {
+    logger.warn('Too many skip or undefined component');
+    return null;
+  }
+
+  let renderedJSX = code;
+  const Type = renderedJSX.type;
+
+  for (let i = 0; i < options.skip; i += 1) {
+    if (typeof renderedJSX === 'undefined') {
+      logger.warn('Cannot skip undefined element');
+      return null;
+    }
+
+    if (React.Children.count(renderedJSX) > 1) {
+      logger.warn('Trying to skip an array of elements');
+      return null;
+    }
+
+    if (typeof renderedJSX.props.children === 'undefined') {
+      logger.warn('Not enough children to skip elements.');
+
+      if (typeof renderedJSX.type === 'function' && renderedJSX.type.name === '') {
+        renderedJSX = <Type {...renderedJSX.props} />;
+      }
+    } else if (typeof renderedJSX.props.children === 'function') {
+      renderedJSX = renderedJSX.props.children();
+    } else {
+      renderedJSX = renderedJSX.props.children;
+    }
+  }
+
+  const displayNameDefaults =
+    typeof options.displayName === 'string'
+      ? { showFunctions: true, displayName: () => options.displayName }
+      : {
+          // To get exotic component names resolving properly
+          displayName: (el: any): string =>
+            el.type.displayName ||
+            getDocgenSection(el.type, 'displayName') ||
+            (el.type.name !== '_default' ? el.type.name : null) ||
+            (typeof el.type === 'function' ? 'No Display Name' : null) ||
+            (isForwardRef(el.type) ? el.type.render.name : null) ||
+            (isMemo(el.type) ? el.type.type.name : null) ||
+            el.type,
+        };
+
+  const filterDefaults = {
+    filterProps: (value: any, key: string): boolean => value !== undefined,
+  };
+
+  const opts = {
+    ...displayNameDefaults,
+    ...filterDefaults,
+    ...options,
+  };
+
+  const result = React.Children.map(code, (c) => {
+    // @ts-ignore FIXME: workaround react-element-to-jsx-string
+    const child = typeof c === 'number' ? c.toString() : c;
+    let string = applyBeforeRender(reactElementToJSXString(child, opts as Options), options);
+
+    if (string.indexOf('&quot;') > -1) {
+      const matches = string.match(/\S+=\\"([^"]*)\\"/g);
+      if (matches) {
+        matches.forEach((match) => {
+          string = string.replace(match, match.replace(/&quot;/g, "'"));
+        });
+      }
+    }
+
+    return string;
+  }).join('\n');
+
+  return result.replace(/function\s+noRefCheck\(\)\s+\{\}/, '() => {}');
+};
+
+const defaultOpts = {
+  skip: 0,
+  showFunctions: false,
+  enableBeautify: true,
+  showDefaultProps: false,
+};
+
+export const skipJsxRender = (context: StoryContext<ReactFramework>) => {
+  const sourceParams = context?.parameters.docs?.source;
+  const isArgsStory = context?.parameters.__isArgsStory;
+
+  // always render if the user forces it
+  if (sourceParams?.type === SourceType.DYNAMIC) {
+    return false;
+  }
+
+  // never render if the user is forcing the block to render code, or
+  // if the user provides code, or if it's not an args story.
+  return !isArgsStory || sourceParams?.code || sourceParams?.type === SourceType.CODE;
+};
+
+const isMdx = (node: any) => node.type?.displayName === 'MDXCreateElement' && !!node.props?.mdxType;
+
+const mdxToJsx = (node: any) => {
+  if (!isMdx(node)) return node;
+  const { mdxType, originalType, children, ...rest } = node.props;
+  let jsxChildren = [] as ReactElement[];
+  if (children) {
+    const array = Array.isArray(children) ? children : [children];
+    jsxChildren = array.map(mdxToJsx);
+  }
+  return createElement(originalType, rest, ...jsxChildren);
+};
+
+export const jsxDecorator = (
+  storyFn: PartialStoryFn<ReactFramework>,
+  context: StoryContext<ReactFramework>
+) => {
+  const channel = addons.getChannel();
+  const skip = skipJsxRender(context);
+  const story = storyFn();
+
+  let jsx = '';
+
+  useEffect(() => {
+    if (!skip) channel.emit(SNIPPET_RENDERED, (context || {}).id, jsx);
+  });
+
+  // We only need to render JSX if the source block is actually going to
+  // consume it. Otherwise it's just slowing us down.
+  if (skip) {
+    return story;
+  }
+
+  const options = {
+    ...defaultOpts,
+    ...(context?.parameters.jsx || {}),
+  } as Required<JSXOptions>;
+
+  // Exclude decorators from source code snippet by default
+  const storyJsx = context?.parameters.docs?.source?.excludeDecorators
+    ? (context.originalStoryFn as ArgsStoryFn<ReactFramework>)(context.args, context)
+    : story;
+
+  const sourceJsx = mdxToJsx(storyJsx);
+
+  const rendered = renderJsx(sourceJsx, options);
+  if (rendered) {
+    jsx = applyTransformSource(rendered, options, context);
+  }
+
+  return story;
+};

--- a/addons/docs/src/frameworks/preact/lib/captions.ts
+++ b/addons/docs/src/frameworks/preact/lib/captions.ts
@@ -1,0 +1,6 @@
+export const CUSTOM_CAPTION = 'custom';
+export const OBJECT_CAPTION = 'object';
+export const ARRAY_CAPTION = 'array';
+export const CLASS_CAPTION = 'class';
+export const FUNCTION_CAPTION = 'func';
+export const ELEMENT_CAPTION = 'element';

--- a/addons/docs/src/frameworks/preact/lib/componentTypes.ts
+++ b/addons/docs/src/frameworks/preact/lib/componentTypes.ts
@@ -1,0 +1,3 @@
+export const isMemo = (component: any) => component.$$typeof === Symbol.for('react.memo');
+export const isForwardRef = (component: any) =>
+  component.$$typeof === Symbol.for('react.forward_ref');

--- a/addons/docs/src/frameworks/preact/lib/defaultValues/createDefaultValue.ts
+++ b/addons/docs/src/frameworks/preact/lib/defaultValues/createDefaultValue.ts
@@ -1,0 +1,81 @@
+import { PropDefaultValue } from '@storybook/components';
+import { FUNCTION_CAPTION, ELEMENT_CAPTION } from '../captions';
+import {
+  InspectionFunction,
+  InspectionResult,
+  InspectionType,
+  InspectionElement,
+  InspectionIdentifiableInferedType,
+  inspectValue,
+} from '../inspection';
+import { isHtmlTag } from '../isHtmlTag';
+import { createSummaryValue, isTooLongForDefaultValueSummary } from '../../../../lib';
+import { generateCode } from '../generateCode';
+import { generateObject } from './generateObject';
+import { generateArray } from './generateArray';
+import { getPrettyIdentifier } from './prettyIdentifier';
+
+function generateFunc({ inferredType, ast }: InspectionResult): PropDefaultValue {
+  const { identifier } = inferredType as InspectionFunction;
+
+  if (identifier != null) {
+    return createSummaryValue(
+      getPrettyIdentifier(inferredType as InspectionIdentifiableInferedType),
+      generateCode(ast)
+    );
+  }
+
+  const prettyCaption = generateCode(ast, true);
+
+  return !isTooLongForDefaultValueSummary(prettyCaption)
+    ? createSummaryValue(prettyCaption)
+    : createSummaryValue(FUNCTION_CAPTION, generateCode(ast));
+}
+
+// All elements are JSX elements.
+// JSX elements are not supported by escodegen.
+function generateElement(
+  defaultValue: string,
+  inspectionResult: InspectionResult
+): PropDefaultValue {
+  const { inferredType } = inspectionResult;
+  const { identifier } = inferredType as InspectionElement;
+
+  if (identifier != null) {
+    if (!isHtmlTag(identifier)) {
+      const prettyIdentifier = getPrettyIdentifier(
+        inferredType as InspectionIdentifiableInferedType
+      );
+
+      return createSummaryValue(prettyIdentifier, defaultValue);
+    }
+  }
+
+  return !isTooLongForDefaultValueSummary(defaultValue)
+    ? createSummaryValue(defaultValue)
+    : createSummaryValue(ELEMENT_CAPTION, defaultValue);
+}
+
+export function createDefaultValue(defaultValue: string): PropDefaultValue {
+  try {
+    const inspectionResult = inspectValue(defaultValue);
+
+    switch (inspectionResult.inferredType.type) {
+      case InspectionType.OBJECT:
+        return generateObject(inspectionResult);
+      case InspectionType.FUNCTION:
+        return generateFunc(inspectionResult);
+      case InspectionType.ELEMENT:
+        return generateElement(defaultValue, inspectionResult);
+      case InspectionType.ARRAY:
+        return generateArray(inspectionResult);
+      default:
+        return null;
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
+
+  return null;
+}

--- a/addons/docs/src/frameworks/preact/lib/defaultValues/createFromRawDefaultProp.ts
+++ b/addons/docs/src/frameworks/preact/lib/defaultValues/createFromRawDefaultProp.ts
@@ -1,0 +1,191 @@
+import { PropDefaultValue } from '@storybook/components';
+import isPlainObject from 'lodash/isPlainObject';
+import isFunction from 'lodash/isFunction';
+import isString from 'lodash/isString';
+// @ts-ignore
+import reactElementToJSXString from 'react-element-to-jsx-string';
+import { createSummaryValue, isTooLongForDefaultValueSummary } from '../../../../lib';
+import { PropDef } from '../../../../lib/docgen';
+import { inspectValue, InspectionFunction } from '../inspection';
+import { generateObject } from './generateObject';
+import { generateArray } from './generateArray';
+import { getPrettyElementIdentifier, getPrettyFuncIdentifier } from './prettyIdentifier';
+import { OBJECT_CAPTION, FUNCTION_CAPTION, ELEMENT_CAPTION } from '../captions';
+import { isHtmlTag } from '../isHtmlTag';
+
+export type TypeResolver = (rawDefaultProp: any, propDef: PropDef) => PropDefaultValue;
+
+export interface TypeResolvers {
+  string: TypeResolver;
+  object: TypeResolver;
+  function: TypeResolver;
+  default: TypeResolver;
+}
+
+function isReactElement(element: any): boolean {
+  return element.$$typeof != null;
+}
+
+export function extractFunctionName(func: Function, propName: string): string {
+  const { name } = func;
+
+  // Comparison with the prop name is to discard inferred function names.
+  if (name !== '' && name !== 'anonymous' && name !== propName) {
+    return name;
+  }
+
+  return null;
+}
+
+const stringResolver: TypeResolver = (rawDefaultProp) => {
+  return createSummaryValue(JSON.stringify(rawDefaultProp));
+};
+
+function generateReactObject(rawDefaultProp: any) {
+  const { type } = rawDefaultProp;
+  const { displayName } = type;
+
+  const jsx = reactElementToJSXString(rawDefaultProp, {});
+
+  if (displayName != null) {
+    const prettyIdentifier = getPrettyElementIdentifier(displayName);
+
+    return createSummaryValue(prettyIdentifier, jsx);
+  }
+
+  if (isString(type)) {
+    // This is an HTML element.
+    if (isHtmlTag(type)) {
+      const jsxCompact = reactElementToJSXString(rawDefaultProp, { tabStop: 0 });
+      const jsxSummary = jsxCompact.replace(/\r?\n|\r/g, '');
+
+      if (!isTooLongForDefaultValueSummary(jsxSummary)) {
+        return createSummaryValue(jsxSummary);
+      }
+    }
+  }
+
+  return createSummaryValue(ELEMENT_CAPTION, jsx);
+}
+
+const objectResolver: TypeResolver = (rawDefaultProp) => {
+  if (isReactElement(rawDefaultProp) && rawDefaultProp.type != null) {
+    return generateReactObject(rawDefaultProp);
+  }
+
+  if (isPlainObject(rawDefaultProp)) {
+    const inspectionResult = inspectValue(JSON.stringify(rawDefaultProp));
+
+    return generateObject(inspectionResult);
+  }
+
+  if (Array.isArray(rawDefaultProp)) {
+    const inspectionResult = inspectValue(JSON.stringify(rawDefaultProp));
+
+    return generateArray(inspectionResult);
+  }
+
+  return createSummaryValue(OBJECT_CAPTION);
+};
+
+const functionResolver: TypeResolver = (rawDefaultProp, propDef) => {
+  let isElement = false;
+  let inspectionResult;
+
+  // Try to display the name of the component. The body of the component is omitted since the code has been transpiled.
+  if (isFunction(rawDefaultProp.render)) {
+    isElement = true;
+  } else if (rawDefaultProp.prototype != null && isFunction(rawDefaultProp.prototype.render)) {
+    isElement = true;
+  } else {
+    let innerElement;
+
+    try {
+      inspectionResult = inspectValue(rawDefaultProp.toString());
+
+      const { hasParams, params } = inspectionResult.inferredType as InspectionFunction;
+      if (hasParams) {
+        // It might be a functional component accepting props.
+        if (params.length === 1 && params[0].type === 'ObjectPattern') {
+          innerElement = rawDefaultProp({});
+        }
+      } else {
+        innerElement = rawDefaultProp();
+      }
+
+      if (innerElement != null) {
+        if (isReactElement(innerElement)) {
+          isElement = true;
+        }
+      }
+    } catch (e) {
+      // do nothing.
+    }
+  }
+
+  const funcName = extractFunctionName(rawDefaultProp, propDef.name);
+  if (funcName != null) {
+    if (isElement) {
+      return createSummaryValue(getPrettyElementIdentifier(funcName));
+    }
+
+    if (inspectionResult != null) {
+      inspectionResult = inspectValue(rawDefaultProp.toString());
+    }
+
+    const { hasParams } = inspectionResult.inferredType as InspectionFunction;
+
+    return createSummaryValue(getPrettyFuncIdentifier(funcName, hasParams));
+  }
+
+  return createSummaryValue(isElement ? ELEMENT_CAPTION : FUNCTION_CAPTION);
+};
+
+const defaultResolver: TypeResolver = (rawDefaultProp) => {
+  return createSummaryValue(rawDefaultProp.toString());
+};
+
+const DEFAULT_TYPE_RESOLVERS: TypeResolvers = {
+  string: stringResolver,
+  object: objectResolver,
+  function: functionResolver,
+  default: defaultResolver,
+};
+
+export function createTypeResolvers(customResolvers: Partial<TypeResolvers> = {}): TypeResolvers {
+  return {
+    ...DEFAULT_TYPE_RESOLVERS,
+    ...customResolvers,
+  };
+}
+
+// When react-docgen cannot provide a defaultValue we take it from the raw defaultProp.
+// It works fine for types that are not transpiled. For the types that are transpiled, we can only provide partial support.
+// This means that:
+//   - The detail might not be available.
+//   - Identifiers might not be "prettified" for all the types.
+export function createDefaultValueFromRawDefaultProp(
+  rawDefaultProp: any,
+  propDef: PropDef,
+  typeResolvers: TypeResolvers = DEFAULT_TYPE_RESOLVERS
+): PropDefaultValue {
+  try {
+    // Keep the extra () otherwise it will fail for functions.
+    switch (typeof rawDefaultProp) {
+      case 'string':
+        return typeResolvers.string(rawDefaultProp, propDef);
+      case 'object':
+        return typeResolvers.object(rawDefaultProp, propDef);
+      case 'function': {
+        return typeResolvers.function(rawDefaultProp, propDef);
+      }
+      default:
+        return typeResolvers.default(rawDefaultProp, propDef);
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
+
+  return null;
+}

--- a/addons/docs/src/frameworks/preact/lib/defaultValues/generateArray.ts
+++ b/addons/docs/src/frameworks/preact/lib/defaultValues/generateArray.ts
@@ -1,0 +1,19 @@
+import { PropDefaultValue } from '@storybook/components';
+import { ARRAY_CAPTION } from '../captions';
+import { InspectionResult, InspectionArray } from '../inspection';
+import { createSummaryValue, isTooLongForDefaultValueSummary } from '../../../../lib';
+import { generateArrayCode } from '../generateCode';
+
+export function generateArray({ inferredType, ast }: InspectionResult): PropDefaultValue {
+  const { depth } = inferredType as InspectionArray;
+
+  if (depth <= 2) {
+    const compactArray = generateArrayCode(ast, true);
+
+    if (!isTooLongForDefaultValueSummary(compactArray)) {
+      return createSummaryValue(compactArray);
+    }
+  }
+
+  return createSummaryValue(ARRAY_CAPTION, generateArrayCode(ast));
+}

--- a/addons/docs/src/frameworks/preact/lib/defaultValues/generateObject.ts
+++ b/addons/docs/src/frameworks/preact/lib/defaultValues/generateObject.ts
@@ -1,0 +1,19 @@
+import { PropDefaultValue } from '@storybook/components';
+import { OBJECT_CAPTION } from '../captions';
+import { InspectionResult, InspectionArray } from '../inspection';
+import { createSummaryValue, isTooLongForDefaultValueSummary } from '../../../../lib';
+import { generateObjectCode } from '../generateCode';
+
+export function generateObject({ inferredType, ast }: InspectionResult): PropDefaultValue {
+  const { depth } = inferredType as InspectionArray;
+
+  if (depth === 1) {
+    const compactObject = generateObjectCode(ast, true);
+
+    if (!isTooLongForDefaultValueSummary(compactObject)) {
+      return createSummaryValue(compactObject);
+    }
+  }
+
+  return createSummaryValue(OBJECT_CAPTION, generateObjectCode(ast));
+}

--- a/addons/docs/src/frameworks/preact/lib/defaultValues/index.ts
+++ b/addons/docs/src/frameworks/preact/lib/defaultValues/index.ts
@@ -1,0 +1,2 @@
+export * from './createDefaultValue';
+export * from './createFromRawDefaultProp';

--- a/addons/docs/src/frameworks/preact/lib/defaultValues/prettyIdentifier.ts
+++ b/addons/docs/src/frameworks/preact/lib/defaultValues/prettyIdentifier.ts
@@ -1,0 +1,26 @@
+import {
+  InspectionIdentifiableInferedType,
+  InspectionFunction,
+  InspectionType,
+} from '../inspection';
+
+export function getPrettyIdentifier(inferredType: InspectionIdentifiableInferedType): string {
+  const { type, identifier } = inferredType;
+
+  switch (type) {
+    case InspectionType.FUNCTION:
+      return getPrettyFuncIdentifier(identifier, (inferredType as InspectionFunction).hasParams);
+    case InspectionType.ELEMENT:
+      return getPrettyElementIdentifier(identifier);
+    default:
+      return identifier;
+  }
+}
+
+export function getPrettyFuncIdentifier(identifier: string, hasArguments: boolean): string {
+  return hasArguments ? `${identifier}( ... )` : `${identifier}()`;
+}
+
+export function getPrettyElementIdentifier(identifier: string) {
+  return `<${identifier} />`;
+}

--- a/addons/docs/src/frameworks/preact/lib/generateCode.ts
+++ b/addons/docs/src/frameworks/preact/lib/generateCode.ts
@@ -1,0 +1,70 @@
+import { generate } from 'escodegen';
+import dedent from 'ts-dedent';
+
+const BASIC_OPTIONS = {
+  format: {
+    indent: {
+      style: '  ',
+    },
+    semicolons: false,
+  },
+};
+
+const COMPACT_OPTIONS = {
+  ...BASIC_OPTIONS,
+  format: {
+    newline: '',
+  },
+};
+
+const PRETTY_OPTIONS = {
+  ...BASIC_OPTIONS,
+};
+
+export function generateCode(ast: any, compact = false): string {
+  return generate(ast, compact ? COMPACT_OPTIONS : PRETTY_OPTIONS);
+}
+
+export function generateObjectCode(ast: any, compact = false): string {
+  return !compact ? generateCode(ast) : generateCompactObjectCode(ast);
+}
+
+function generateCompactObjectCode(ast: any): string {
+  let result = generateCode(ast, true);
+
+  // Cannot get escodegen to add a space before the last } with the compact mode settings.
+  // Fix it until a better solution is found.
+  if (!result.endsWith(' }')) {
+    result = `${result.slice(0, -1)} }`;
+  }
+
+  return result;
+}
+
+export function generateArrayCode(ast: any, compact = false): string {
+  return !compact ? generateMultilineArrayCode(ast) : generateCompactArrayCode(ast);
+}
+
+function generateMultilineArrayCode(ast: any): string {
+  let result = generateCode(ast);
+
+  // escodegen add extra spacing before the closing bracket of a multiple line array with a nested object.
+  // Fix it until a better solution is found.
+  if (result.endsWith('  }]')) {
+    result = dedent(result);
+  }
+
+  return result;
+}
+
+function generateCompactArrayCode(ast: any): string {
+  let result = generateCode(ast, true);
+
+  // escodegen add extra an extra before the opening bracket of a compact array that contains primitive values.
+  // Fix it until a better solution is found.
+  if (result.startsWith('[    ')) {
+    result = result.replace('[    ', '[');
+  }
+
+  return result;
+}

--- a/addons/docs/src/frameworks/preact/lib/index.ts
+++ b/addons/docs/src/frameworks/preact/lib/index.ts
@@ -1,0 +1,4 @@
+export * from './captions';
+export * from './isHtmlTag';
+export * from './generateCode';
+export * from './componentTypes';

--- a/addons/docs/src/frameworks/preact/lib/inspection/acornParser.test.ts
+++ b/addons/docs/src/frameworks/preact/lib/inspection/acornParser.test.ts
@@ -1,0 +1,254 @@
+import { parse } from './acornParser';
+import {
+  InspectionType,
+  InspectionElement,
+  InspectionObject,
+  InspectionArray,
+  InspectionIdentifier,
+  InspectionLiteral,
+  InspectionFunction,
+  InspectionUnknown,
+} from './types';
+
+describe('parse', () => {
+  describe('expression', () => {
+    it('support HTML element', () => {
+      const result = parse('<div>Hello!</div>');
+      const inferredType = result.inferredType as InspectionElement;
+
+      expect(inferredType.type).toBe(InspectionType.ELEMENT);
+      expect(inferredType.identifier).toBe('div');
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support React declaration', () => {
+      const result = parse('<FunctionalComponent />');
+      const inferredType = result.inferredType as InspectionElement;
+
+      expect(inferredType.type).toBe(InspectionType.ELEMENT);
+      expect(inferredType.identifier).toBe('FunctionalComponent');
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support anonymous functional React component', () => {
+      const result = parse('() => { return <div>Hey!</div>; }');
+      const inferredType = result.inferredType as InspectionElement;
+
+      expect(inferredType.type).toBe(InspectionType.ELEMENT);
+      expect(inferredType.identifier).toBeUndefined();
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support named functional React component', () => {
+      const result = parse('function NamedFunctionalComponent() { return <div>Hey!</div>; }');
+      const inferredType = result.inferredType as InspectionElement;
+
+      expect(inferredType.type).toBe(InspectionType.ELEMENT);
+      expect(inferredType.identifier).toBe('NamedFunctionalComponent');
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support class React component', () => {
+      const result = parse(`
+        class ClassComponent extends React.PureComponent {
+          render() {
+            return <div>Hey!</div>;
+          }
+      }`);
+      const inferredType = result.inferredType as InspectionElement;
+
+      expect(inferredType.type).toBe(InspectionType.ELEMENT);
+      expect(inferredType.identifier).toBe('ClassComponent');
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support PropTypes.shape', () => {
+      const result = parse('PropTypes.shape({ foo: PropTypes.string })');
+      const inferredType = result.inferredType as InspectionObject;
+
+      expect(inferredType.type).toBe(InspectionType.OBJECT);
+      expect(inferredType.depth).toBe(1);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support deep PropTypes.shape', () => {
+      const result = parse('PropTypes.shape({ foo: PropTypes.shape({ bar: PropTypes.string }) })');
+      const inferredType = result.inferredType as InspectionObject;
+
+      expect(inferredType.type).toBe(InspectionType.OBJECT);
+      expect(inferredType.depth).toBe(2);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support shape', () => {
+      const result = parse('shape({ foo: string })');
+      const inferredType = result.inferredType as InspectionObject;
+
+      expect(inferredType.type).toBe(InspectionType.OBJECT);
+      expect(inferredType.depth).toBe(1);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support deep shape', () => {
+      const result = parse('shape({ foo: shape({ bar: string }) })');
+      const inferredType = result.inferredType as InspectionObject;
+
+      expect(inferredType.type).toBe(InspectionType.OBJECT);
+      expect(inferredType.depth).toBe(2);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support single prop object literal', () => {
+      const result = parse('{ foo: PropTypes.string }');
+      const inferredType = result.inferredType as InspectionObject;
+
+      expect(inferredType.type).toBe(InspectionType.OBJECT);
+      expect(inferredType.depth).toBe(1);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support multi prop object literal', () => {
+      const result = parse(`
+      {
+          foo: PropTypes.string,
+          bar: PropTypes.string
+      }`);
+      const inferredType = result.inferredType as InspectionObject;
+
+      expect(inferredType.type).toBe(InspectionType.OBJECT);
+      expect(inferredType.depth).toBe(1);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support deep object literal', () => {
+      const result = parse(`
+      {
+          foo: {
+            hey: PropTypes.string
+          },
+          bar: PropTypes.string,
+          hey: {
+            ho: PropTypes.string
+          }
+      }`);
+      const inferredType = result.inferredType as InspectionObject;
+
+      expect(inferredType.type).toBe(InspectionType.OBJECT);
+      expect(inferredType.depth).toBe(2);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support required prop', () => {
+      const result = parse('{ foo: PropTypes.string.isRequired }');
+      const inferredType = result.inferredType as InspectionObject;
+
+      expect(inferredType.type).toBe(InspectionType.OBJECT);
+      expect(inferredType.depth).toBe(1);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support array', () => {
+      const result = parse("['bottom-left', 'botton-center', 'bottom-right']");
+      const inferredType = result.inferredType as InspectionArray;
+
+      expect(inferredType.type).toBe(InspectionType.ARRAY);
+      expect(inferredType.depth).toBe(1);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support deep array', () => {
+      const result = parse("['bottom-left', { foo: string }, [['hey', 'ho']]]");
+      const inferredType = result.inferredType as InspectionArray;
+
+      expect(inferredType.type).toBe(InspectionType.ARRAY);
+      expect(inferredType.depth).toBe(3);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support object identifier', () => {
+      const result = parse('NAMED_OBJECT');
+      const inferredType = result.inferredType as InspectionIdentifier;
+
+      expect(inferredType.type).toBe(InspectionType.IDENTIFIER);
+      expect(inferredType.identifier).toBe('NAMED_OBJECT');
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support anonymous function', () => {
+      const result = parse('() => {}');
+      const inferredType = result.inferredType as InspectionFunction;
+
+      expect(inferredType.type).toBe(InspectionType.FUNCTION);
+      expect(inferredType.identifier).toBeUndefined();
+      expect(inferredType.hasParams).toBeFalsy();
+      expect(inferredType.params.length).toBe(0);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support anonymous function with arguments', () => {
+      const result = parse('(a, b) => {}');
+      const inferredType = result.inferredType as InspectionFunction;
+
+      expect(inferredType.type).toBe(InspectionType.FUNCTION);
+      expect(inferredType.identifier).toBeUndefined();
+      expect(inferredType.hasParams).toBeTruthy();
+      expect(inferredType.params.length).toBe(2);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support named function', () => {
+      const result = parse('function concat() {}');
+      const inferredType = result.inferredType as InspectionFunction;
+
+      expect(inferredType.type).toBe(InspectionType.FUNCTION);
+      expect(inferredType.identifier).toBe('concat');
+      expect(inferredType.hasParams).toBeFalsy();
+      expect(inferredType.params.length).toBe(0);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support named function with arguments', () => {
+      const result = parse('function concat(a, b) {}');
+      const inferredType = result.inferredType as InspectionFunction;
+
+      expect(inferredType.type).toBe(InspectionType.FUNCTION);
+      expect(inferredType.identifier).toBe('concat');
+      expect(inferredType.hasParams).toBeTruthy();
+      expect(inferredType.params.length).toBe(2);
+      expect(result.ast).toBeDefined();
+    });
+
+    it('support class', () => {
+      const result = parse('class Foo {}');
+      const inferredType = result.inferredType as InspectionFunction;
+
+      expect(inferredType.type).toBe(InspectionType.CLASS);
+      expect(inferredType.identifier).toBe('Foo');
+      expect(result.ast).toBeDefined();
+    });
+
+    [
+      { name: 'string', value: "'string value'" },
+      { name: 'numeric', value: '1' },
+      { name: 'boolean (true)', value: 'true' },
+      { name: 'boolean (false)', value: 'false' },
+      { name: 'null', value: 'null' },
+    ].forEach((x) => {
+      it(`support ${x.name}`, () => {
+        const result = parse(x.value);
+        const inferredType = result.inferredType as InspectionLiteral;
+
+        expect(inferredType.type).toBe(InspectionType.LITERAL);
+        expect(result.ast).toBeDefined();
+      });
+    });
+
+    it("returns Unknown when it's not supported", () => {
+      const result = parse("Symbol('foo')");
+      const inferredType = result.inferredType as InspectionUnknown;
+
+      expect(inferredType.type).toBe(InspectionType.UNKNOWN);
+      expect(result.ast).toBeDefined();
+    });
+  });
+});

--- a/addons/docs/src/frameworks/preact/lib/inspection/acornParser.ts
+++ b/addons/docs/src/frameworks/preact/lib/inspection/acornParser.ts
@@ -1,0 +1,234 @@
+import { Parser } from 'acorn';
+import jsx from 'acorn-jsx';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import estree from 'estree';
+import * as acornWalk from 'acorn-walk';
+import {
+  InspectionType,
+  InspectionLiteral,
+  InspectionElement,
+  InspectionFunction,
+  InspectionClass,
+  InspectionObject,
+  InspectionUnknown,
+  InspectionIdentifier,
+  InspectionArray,
+  InspectionInferedType,
+} from './types';
+
+interface ParsingResult<T> {
+  inferredType: T;
+  ast: any;
+}
+
+const ACORN_WALK_VISITORS = {
+  // @ts-ignore
+  ...acornWalk.base,
+  JSXElement: () => {},
+};
+
+const acornParser = Parser.extend(jsx());
+
+// Cannot use "estree.Identifier" type because this function also support "JSXIdentifier".
+function extractIdentifierName(identifierNode: any) {
+  return identifierNode != null ? identifierNode.name : null;
+}
+
+function filterAncestors(ancestors: estree.Node[]): estree.Node[] {
+  return ancestors.filter((x) => x.type === 'ObjectExpression' || x.type === 'ArrayExpression');
+}
+
+function calculateNodeDepth(node: estree.Expression): number {
+  const depths: number[] = [];
+
+  acornWalk.ancestor(
+    // @ts-ignore
+    node,
+    {
+      ObjectExpression(_: any, ancestors: estree.Node[]) {
+        depths.push(filterAncestors(ancestors).length);
+      },
+      ArrayExpression(_: any, ancestors: estree.Node[]) {
+        depths.push(filterAncestors(ancestors).length);
+      },
+    },
+    ACORN_WALK_VISITORS
+  );
+
+  return Math.max(...depths);
+}
+
+function parseIdentifier(identifierNode: estree.Identifier): ParsingResult<InspectionIdentifier> {
+  return {
+    inferredType: {
+      type: InspectionType.IDENTIFIER,
+      identifier: extractIdentifierName(identifierNode),
+    },
+    ast: identifierNode,
+  };
+}
+
+function parseLiteral(literalNode: estree.Literal): ParsingResult<InspectionLiteral> {
+  return {
+    inferredType: { type: InspectionType.LITERAL },
+    ast: literalNode,
+  };
+}
+
+function parseFunction(
+  funcNode: estree.FunctionExpression | estree.ArrowFunctionExpression
+): ParsingResult<InspectionFunction | InspectionElement> {
+  let innerJsxElementNode;
+
+  // If there is at least a JSXElement in the body of the function, then it's a React component.
+  acornWalk.simple(
+    // @ts-ignore
+    funcNode.body,
+    {
+      JSXElement(node: any) {
+        innerJsxElementNode = node;
+      },
+    },
+    ACORN_WALK_VISITORS
+  );
+
+  const isJsx = innerJsxElementNode != null;
+
+  const inferredType: InspectionFunction | InspectionElement = {
+    type: isJsx ? InspectionType.ELEMENT : InspectionType.FUNCTION,
+    params: funcNode.params,
+    hasParams: funcNode.params.length !== 0,
+  };
+
+  const identifierName = extractIdentifierName((funcNode as estree.FunctionExpression).id);
+  if (identifierName != null) {
+    inferredType.identifier = identifierName;
+  }
+
+  return {
+    inferredType,
+    ast: funcNode,
+  };
+}
+
+function parseClass(
+  classNode: estree.ClassExpression
+): ParsingResult<InspectionClass | InspectionElement> {
+  let innerJsxElementNode;
+
+  // If there is at least a JSXElement in the body of the class, then it's a React component.
+  acornWalk.simple(
+    // @ts-ignore
+    classNode.body,
+    {
+      JSXElement(node: any) {
+        innerJsxElementNode = node;
+      },
+    },
+    ACORN_WALK_VISITORS
+  );
+
+  const inferredType: any = {
+    type: innerJsxElementNode != null ? InspectionType.ELEMENT : InspectionType.CLASS,
+    identifier: extractIdentifierName(classNode.id),
+  };
+
+  return {
+    inferredType,
+    ast: classNode,
+  };
+}
+
+function parseJsxElement(jsxElementNode: any): ParsingResult<InspectionElement> {
+  const inferredType: InspectionElement = {
+    type: InspectionType.ELEMENT,
+  };
+
+  const identifierName = extractIdentifierName(jsxElementNode.openingElement.name);
+  if (identifierName != null) {
+    inferredType.identifier = identifierName;
+  }
+
+  return {
+    inferredType,
+    ast: jsxElementNode,
+  };
+}
+
+function parseCall(callNode: estree.CallExpression): ParsingResult<InspectionObject> {
+  const identifierNode =
+    callNode.callee.type === 'MemberExpression' ? callNode.callee.property : callNode.callee;
+
+  const identifierName = extractIdentifierName(identifierNode);
+  if (identifierName === 'shape') {
+    return parseObject(callNode.arguments[0] as estree.ObjectExpression);
+  }
+
+  return null;
+}
+
+function parseObject(objectNode: estree.ObjectExpression): ParsingResult<InspectionObject> {
+  return {
+    inferredType: { type: InspectionType.OBJECT, depth: calculateNodeDepth(objectNode) },
+    ast: objectNode,
+  };
+}
+
+function parseArray(arrayNode: estree.ArrayExpression): ParsingResult<InspectionArray> {
+  return {
+    inferredType: { type: InspectionType.ARRAY, depth: calculateNodeDepth(arrayNode) },
+    ast: arrayNode,
+  };
+}
+
+// Cannot set "expression" type to "estree.Expression" because the type doesn't include JSX.
+function parseExpression(expression: any): ParsingResult<InspectionInferedType> {
+  switch (expression.type) {
+    case 'Identifier':
+      return parseIdentifier(expression);
+    case 'Literal':
+      return parseLiteral(expression);
+    case 'FunctionExpression':
+    case 'ArrowFunctionExpression':
+      return parseFunction(expression);
+    case 'ClassExpression':
+      return parseClass(expression);
+    case 'JSXElement':
+      return parseJsxElement(expression);
+    case 'CallExpression':
+      return parseCall(expression);
+    case 'ObjectExpression':
+      return parseObject(expression);
+    case 'ArrayExpression':
+      return parseArray(expression);
+    default:
+      return null;
+  }
+}
+
+export function parse(value: string): ParsingResult<InspectionInferedType> {
+  const ast = (acornParser.parse(`(${value})`) as unknown) as estree.Program;
+
+  let parsingResult: ParsingResult<InspectionUnknown> = {
+    inferredType: { type: InspectionType.UNKNOWN },
+    ast,
+  };
+
+  if (ast.body[0] != null) {
+    const rootNode = ast.body[0];
+
+    switch (rootNode.type) {
+      case 'ExpressionStatement': {
+        const expressionResult = parseExpression(rootNode.expression);
+        if (expressionResult != null) {
+          parsingResult = expressionResult as any;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return parsingResult;
+}

--- a/addons/docs/src/frameworks/preact/lib/inspection/index.ts
+++ b/addons/docs/src/frameworks/preact/lib/inspection/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './inspectValue';

--- a/addons/docs/src/frameworks/preact/lib/inspection/inspectValue.ts
+++ b/addons/docs/src/frameworks/preact/lib/inspection/inspectValue.ts
@@ -1,0 +1,14 @@
+import { parse } from './acornParser';
+import { InspectionResult, InspectionType } from './types';
+
+export function inspectValue(value: string): InspectionResult {
+  try {
+    const parsingResult = parse(value);
+
+    return { ...parsingResult };
+  } catch (e) {
+    // do nothing.
+  }
+
+  return { inferredType: { type: InspectionType.UNKNOWN } };
+}

--- a/addons/docs/src/frameworks/preact/lib/inspection/types.ts
+++ b/addons/docs/src/frameworks/preact/lib/inspection/types.ts
@@ -1,0 +1,65 @@
+export enum InspectionType {
+  IDENTIFIER = 'Identifier',
+  LITERAL = 'Literal',
+  OBJECT = 'Object',
+  ARRAY = 'Array',
+  FUNCTION = 'Function',
+  CLASS = 'Class',
+  ELEMENT = 'Element',
+  UNKNOWN = 'Unknown',
+}
+
+export interface InspectionInferedType {
+  type: InspectionType;
+}
+
+export interface InspectionIdentifier extends InspectionInferedType {
+  type: InspectionType.IDENTIFIER;
+  identifier: string;
+}
+
+export interface InspectionLiteral extends InspectionInferedType {
+  type: InspectionType.LITERAL;
+}
+
+export interface InspectionObject extends InspectionInferedType {
+  type: InspectionType.OBJECT;
+  depth: number;
+}
+
+export interface InspectionArray extends InspectionInferedType {
+  type: InspectionType.ARRAY;
+  depth: number;
+}
+
+export interface InspectionClass extends InspectionInferedType {
+  type: InspectionType.CLASS;
+  identifier: string;
+}
+
+export interface InspectionFunction extends InspectionInferedType {
+  type: InspectionType.FUNCTION;
+  identifier?: string;
+  params: any[];
+  hasParams: boolean;
+}
+
+export interface InspectionElement extends InspectionInferedType {
+  type: InspectionType.ELEMENT;
+  identifier?: string;
+}
+
+export interface InspectionUnknown extends InspectionInferedType {
+  type: InspectionType.UNKNOWN;
+}
+
+export type InspectionIdentifiableInferedType =
+  | InspectionIdentifier
+  | InspectionClass
+  | InspectionFunction
+  | InspectionElement;
+
+export interface InspectionResult {
+  inferredType: InspectionInferedType;
+  ast?: any;
+}

--- a/addons/docs/src/frameworks/preact/lib/isHtmlTag.ts
+++ b/addons/docs/src/frameworks/preact/lib/isHtmlTag.ts
@@ -1,0 +1,5 @@
+import htmlTags from 'html-tags';
+
+export function isHtmlTag(tagName: string): boolean {
+  return htmlTags.includes(tagName.toLowerCase());
+}

--- a/addons/docs/src/frameworks/preact/propTypes/createType.ts
+++ b/addons/docs/src/frameworks/preact/propTypes/createType.ts
@@ -1,0 +1,409 @@
+import { PropType } from '@storybook/components';
+import { createSummaryValue, isTooLongForTypeSummary } from '../../../lib';
+import { ExtractedProp, DocgenPropType } from '../../../lib/docgen';
+import {
+  generateFuncSignature,
+  generateShortFuncSignature,
+  toMultilineSignature,
+} from './generateFuncSignature';
+import {
+  OBJECT_CAPTION,
+  ARRAY_CAPTION,
+  CLASS_CAPTION,
+  FUNCTION_CAPTION,
+  ELEMENT_CAPTION,
+  CUSTOM_CAPTION,
+  isHtmlTag,
+  generateObjectCode,
+  generateCode,
+} from '../lib';
+import {
+  InspectionType,
+  inspectValue,
+  InspectionElement,
+  InspectionObject,
+  InspectionArray,
+} from '../lib/inspection';
+
+const MAX_FUNC_LENGTH = 150;
+
+enum PropTypesType {
+  CUSTOM = 'custom',
+  ANY = 'any',
+  FUNC = 'func',
+  SHAPE = 'shape',
+  OBJECT = 'object',
+  INSTANCEOF = 'instanceOf',
+  OBJECTOF = 'objectOf',
+  UNION = 'union',
+  ENUM = 'enum',
+  ARRAYOF = 'arrayOf',
+  ELEMENT = 'element',
+  ELEMENTTYPE = 'elementType',
+  NODE = 'node',
+}
+
+interface EnumValue {
+  value: string;
+  computed: boolean;
+}
+
+interface TypeDef {
+  name: string;
+  short: string;
+  compact: string;
+  full: string;
+  inferredType?: InspectionType;
+}
+
+function createTypeDef({
+  name,
+  short,
+  compact,
+  full,
+  inferredType,
+}: {
+  name: string;
+  short: string;
+  compact: string;
+  full?: string;
+  inferredType?: InspectionType;
+}): TypeDef {
+  return {
+    name,
+    short,
+    compact,
+    full: full != null ? full : short,
+    inferredType,
+  };
+}
+
+function cleanPropTypes(value: string): string {
+  return value.replace(/PropTypes./g, '').replace(/.isRequired/g, '');
+}
+
+function splitIntoLines(value: string): string[] {
+  return value.split(/\r?\n/);
+}
+
+function prettyObject(ast: any, compact = false): string {
+  return cleanPropTypes(generateObjectCode(ast, compact));
+}
+
+function prettyArray(ast: any, compact = false): string {
+  return cleanPropTypes(generateCode(ast, compact));
+}
+
+function getCaptionForInspectionType(type: InspectionType): string {
+  switch (type) {
+    case InspectionType.OBJECT:
+      return OBJECT_CAPTION;
+    case InspectionType.ARRAY:
+      return ARRAY_CAPTION;
+    case InspectionType.CLASS:
+      return CLASS_CAPTION;
+    case InspectionType.FUNCTION:
+      return FUNCTION_CAPTION;
+    case InspectionType.ELEMENT:
+      return ELEMENT_CAPTION;
+    default:
+      return CUSTOM_CAPTION;
+  }
+}
+
+function generateTypeFromString(value: string, originalTypeName: string): TypeDef {
+  const { inferredType, ast } = inspectValue(value);
+  const { type } = inferredType;
+
+  let short;
+  let compact;
+  let full;
+
+  switch (type) {
+    case InspectionType.IDENTIFIER:
+    case InspectionType.LITERAL:
+      short = value;
+      compact = value;
+      break;
+    case InspectionType.OBJECT: {
+      const { depth } = inferredType as InspectionObject;
+
+      short = OBJECT_CAPTION;
+      compact = depth === 1 ? prettyObject(ast, true) : null;
+      full = prettyObject(ast);
+      break;
+    }
+    case InspectionType.ELEMENT: {
+      const { identifier } = inferredType as InspectionElement;
+
+      short = identifier != null && !isHtmlTag(identifier) ? identifier : ELEMENT_CAPTION;
+      compact = splitIntoLines(value).length === 1 ? value : null;
+      full = value;
+      break;
+    }
+    case InspectionType.ARRAY: {
+      const { depth } = inferredType as InspectionArray;
+
+      short = ARRAY_CAPTION;
+      compact = depth <= 2 ? prettyArray(ast, true) : null;
+      full = prettyArray(ast);
+      break;
+    }
+    default:
+      short = getCaptionForInspectionType(type);
+      compact = splitIntoLines(value).length === 1 ? value : null;
+      full = value;
+      break;
+  }
+
+  return createTypeDef({
+    name: originalTypeName,
+    short,
+    compact,
+    full,
+    inferredType: type,
+  });
+}
+
+function generateCustom({ raw }: DocgenPropType): TypeDef {
+  if (raw != null) {
+    return generateTypeFromString(raw, PropTypesType.CUSTOM);
+  }
+
+  return createTypeDef({
+    name: PropTypesType.CUSTOM,
+    short: CUSTOM_CAPTION,
+    compact: CUSTOM_CAPTION,
+  });
+}
+
+function generateFunc(extractedProp: ExtractedProp): TypeDef {
+  const { jsDocTags } = extractedProp;
+
+  if (jsDocTags != null) {
+    if (jsDocTags.params != null || jsDocTags.returns != null) {
+      return createTypeDef({
+        name: PropTypesType.FUNC,
+        short: generateShortFuncSignature(jsDocTags.params, jsDocTags.returns),
+        compact: null,
+        full: generateFuncSignature(jsDocTags.params, jsDocTags.returns),
+      });
+    }
+  }
+
+  return createTypeDef({
+    name: PropTypesType.FUNC,
+    short: FUNCTION_CAPTION,
+    compact: FUNCTION_CAPTION,
+  });
+}
+
+function generateShape(type: DocgenPropType, extractedProp: ExtractedProp): TypeDef {
+  const fields = Object.keys(type.value)
+    .map((key: string) => `${key}: ${generateType(type.value[key], extractedProp).full}`)
+    .join(', ');
+
+  const { inferredType, ast } = inspectValue(`{ ${fields} }`);
+  const { depth } = inferredType as InspectionObject;
+
+  return createTypeDef({
+    name: PropTypesType.SHAPE,
+    short: OBJECT_CAPTION,
+    compact: depth === 1 && ast ? prettyObject(ast, true) : null,
+    full: ast ? prettyObject(ast) : null,
+  });
+}
+
+function objectOf(of: string): string {
+  return `objectOf(${of})`;
+}
+
+function generateObjectOf(type: DocgenPropType, extractedProp: ExtractedProp): TypeDef {
+  const { short, compact, full } = generateType(type.value, extractedProp);
+
+  return createTypeDef({
+    name: PropTypesType.OBJECTOF,
+    short: objectOf(short),
+    compact: compact != null ? objectOf(compact) : null,
+    full: objectOf(full),
+  });
+}
+
+function generateUnion(type: DocgenPropType, extractedProp: ExtractedProp): TypeDef {
+  if (Array.isArray(type.value)) {
+    const values = type.value.reduce(
+      (acc: any, v: any) => {
+        const { short, compact, full } = generateType(v, extractedProp);
+
+        acc.short.push(short);
+        acc.compact.push(compact);
+        acc.full.push(full);
+
+        return acc;
+      },
+      { short: [], compact: [], full: [] }
+    );
+
+    return createTypeDef({
+      name: PropTypesType.UNION,
+      short: values.short.join(' | '),
+      compact: values.compact.every((x: string) => x != null) ? values.compact.join(' | ') : null,
+      full: values.full.join(' | '),
+    });
+  }
+
+  return createTypeDef({ name: PropTypesType.UNION, short: type.value, compact: null });
+}
+
+function generateEnumValue({ value, computed }: EnumValue): TypeDef {
+  return computed
+    ? generateTypeFromString(value, 'enumvalue')
+    : createTypeDef({ name: 'enumvalue', short: value, compact: value });
+}
+
+function generateEnum(type: DocgenPropType): TypeDef {
+  if (Array.isArray(type.value)) {
+    const values = type.value.reduce(
+      (acc: any, v: EnumValue) => {
+        const { short, compact, full } = generateEnumValue(v);
+
+        acc.short.push(short);
+        acc.compact.push(compact);
+        acc.full.push(full);
+
+        return acc;
+      },
+      { short: [], compact: [], full: [] }
+    );
+
+    return createTypeDef({
+      name: PropTypesType.ENUM,
+      short: values.short.join(' | '),
+      compact: values.compact.every((x: string) => x != null) ? values.compact.join(' | ') : null,
+      full: values.full.join(' | '),
+    });
+  }
+
+  return createTypeDef({ name: PropTypesType.ENUM, short: type.value, compact: type.value });
+}
+
+function braceAfter(of: string): string {
+  return `${of}[]`;
+}
+
+function braceAround(of: string): string {
+  return `[${of}]`;
+}
+
+function createArrayOfObjectTypeDef(short: string, compact: string, full: string): TypeDef {
+  return createTypeDef({
+    name: PropTypesType.ARRAYOF,
+    short: braceAfter(short),
+    compact: compact != null ? braceAround(compact) : null,
+    full: braceAround(full),
+  });
+}
+
+function generateArray(type: DocgenPropType, extractedProp: ExtractedProp): TypeDef {
+  const { name, short, compact, full, inferredType } = generateType(type.value, extractedProp);
+
+  if (name === PropTypesType.CUSTOM) {
+    if (inferredType === InspectionType.OBJECT) {
+      return createArrayOfObjectTypeDef(short, compact, full);
+    }
+  } else if (name === PropTypesType.SHAPE) {
+    return createArrayOfObjectTypeDef(short, compact, full);
+  }
+
+  return createTypeDef({
+    name: PropTypesType.ARRAYOF,
+    short: braceAfter(short),
+    compact: braceAfter(short),
+  });
+}
+
+function generateType(type: DocgenPropType, extractedProp: ExtractedProp): TypeDef {
+  try {
+    switch (type.name) {
+      case PropTypesType.CUSTOM:
+        return generateCustom(type);
+      case PropTypesType.FUNC:
+        return generateFunc(extractedProp);
+      case PropTypesType.SHAPE:
+        return generateShape(type, extractedProp);
+      case PropTypesType.INSTANCEOF:
+        return createTypeDef({
+          name: PropTypesType.INSTANCEOF,
+          short: type.value,
+          compact: type.value,
+        });
+      case PropTypesType.OBJECTOF:
+        return generateObjectOf(type, extractedProp);
+      case PropTypesType.UNION:
+        return generateUnion(type, extractedProp);
+      case PropTypesType.ENUM:
+        return generateEnum(type);
+      case PropTypesType.ARRAYOF:
+        return generateArray(type, extractedProp);
+      default:
+        return createTypeDef({ name: type.name, short: type.name, compact: type.name });
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
+
+  return createTypeDef({ name: 'unknown', short: 'unknown', compact: 'unknown' });
+}
+
+export function createType(extractedProp: ExtractedProp): PropType {
+  const { type } = extractedProp.docgenInfo;
+
+  // A type could be null if a defaultProp has been provided without a type definition.
+  if (type == null) {
+    return null;
+  }
+
+  try {
+    switch (type.name) {
+      case PropTypesType.CUSTOM:
+      case PropTypesType.SHAPE:
+      case PropTypesType.INSTANCEOF:
+      case PropTypesType.OBJECTOF:
+      case PropTypesType.UNION:
+      case PropTypesType.ENUM:
+      case PropTypesType.ARRAYOF: {
+        const { short, compact, full } = generateType(type, extractedProp);
+
+        if (compact != null) {
+          if (!isTooLongForTypeSummary(compact)) {
+            return createSummaryValue(compact);
+          }
+        }
+
+        return createSummaryValue(short, full);
+      }
+      case PropTypesType.FUNC: {
+        const { short, full } = generateType(type, extractedProp);
+
+        let summary = short;
+        let detail;
+
+        if (full.length < MAX_FUNC_LENGTH) {
+          summary = full;
+        } else {
+          detail = toMultilineSignature(full);
+        }
+
+        return createSummaryValue(summary, detail);
+      }
+      default:
+        return null;
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
+
+  return null;
+}

--- a/addons/docs/src/frameworks/preact/propTypes/generateFuncSignature.test.ts
+++ b/addons/docs/src/frameworks/preact/propTypes/generateFuncSignature.test.ts
@@ -1,0 +1,187 @@
+import { generateFuncSignature, generateShortFuncSignature } from './generateFuncSignature';
+import { parseJsDoc } from '../../../lib/jsdocParser';
+
+describe('generateFuncSignature', () => {
+  it('should return an empty string when there is no @params and @returns tags', () => {
+    const result = generateFuncSignature(null, null);
+
+    expect(result).toBe('');
+  });
+
+  it('should return a signature with a single arg when there is a @param tag with a name', () => {
+    const { params, returns } = parseJsDoc('@param event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event)');
+  });
+
+  it('should return a signature with a single arg when there is a @param tag with a name and a type', () => {
+    const { params, returns } = parseJsDoc('@param {SyntheticEvent} event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: SyntheticEvent)');
+  });
+
+  it('should return a signature with a single arg when there is a @param tag with a name, a type and a desc', () => {
+    const { params, returns } = parseJsDoc(
+      '@param {SyntheticEvent} event - React event'
+    ).extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: SyntheticEvent)');
+  });
+
+  it('should support @param of record type', () => {
+    const { params, returns } = parseJsDoc('@param {{a: number}} event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: ({a: number}))');
+  });
+
+  it('should support @param of union type', () => {
+    const { params, returns } = parseJsDoc('@param {(number|boolean)} event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: (number|boolean))');
+  });
+
+  it('should support @param of array type', () => {
+    const { params, returns } = parseJsDoc('@param {number[]} event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: number[])');
+  });
+
+  it('should support @param with a nullable type', () => {
+    const { params, returns } = parseJsDoc('@param {?number} event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: number)');
+  });
+
+  it('should support @param with a non nullable type', () => {
+    const { params, returns } = parseJsDoc('@param {!number} event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: number)');
+  });
+
+  it('should support optional @param with []', () => {
+    const { params, returns } = parseJsDoc('@param {number} [event]').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: number)');
+  });
+
+  it('should support optional @param with =', () => {
+    const { params, returns } = parseJsDoc('@param {number=} event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: number)');
+  });
+
+  it('should support @param of type any', () => {
+    const { params, returns } = parseJsDoc('@param {*} event').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: any)');
+  });
+
+  it('should support multiple @param tags', () => {
+    const { params, returns } = parseJsDoc(
+      '@param {SyntheticEvent} event\n@param {string} customData'
+    ).extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: SyntheticEvent, customData: string)');
+  });
+
+  it('should return a signature with a return type when there is a @returns with a type', () => {
+    const { params, returns } = parseJsDoc('@returns {string}').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('() => string');
+  });
+
+  it('should support @returns of record type', () => {
+    const { params, returns } = parseJsDoc('@returns {{a: number, b: string}}').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('() => ({a: number, b: string})');
+  });
+
+  it('should support @returns of array type', () => {
+    const { params, returns } = parseJsDoc('@returns {integer[]}').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('() => integer[]');
+  });
+
+  it('should support @returns of union type', () => {
+    const { params, returns } = parseJsDoc('@returns {(number|boolean)}').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('() => (number|boolean)');
+  });
+
+  it('should support @returns type any', () => {
+    const { params, returns } = parseJsDoc('@returns {*}').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('() => any');
+  });
+
+  it('should support @returns of type void', () => {
+    const { params, returns } = parseJsDoc('@returns {void}').extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('() => void');
+  });
+
+  it('should return a full signature when there is a single @param tag and a @returns', () => {
+    const { params, returns } = parseJsDoc(
+      '@param {SyntheticEvent} event - React event.\n@returns {string}'
+    ).extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: SyntheticEvent) => string');
+  });
+
+  it('should return a full signature when there is a multiple @param tags and a @returns', () => {
+    const { params, returns } = parseJsDoc(
+      '@param {SyntheticEvent} event - React event.\n@param {string} data\n@returns {string}'
+    ).extractedTags;
+    const result = generateFuncSignature(params, returns);
+
+    expect(result).toBe('(event: SyntheticEvent, data: string) => string');
+  });
+});
+
+describe('generateShortFuncSignature', () => {
+  it('should return an empty string when there is no @params and @returns tags', () => {
+    const result = generateShortFuncSignature(null, null);
+
+    expect(result).toBe('');
+  });
+
+  it('should return ( ... ) when there is @params', () => {
+    const { params, returns } = parseJsDoc('@param event').extractedTags;
+    const result = generateShortFuncSignature(params, returns);
+
+    expect(result).toBe('( ... )');
+  });
+
+  it('should return ( ... ) => returnsType when there is @params and a @returns', () => {
+    const { params, returns } = parseJsDoc('@param event\n@returns {string}').extractedTags;
+    const result = generateShortFuncSignature(params, returns);
+
+    expect(result).toBe('( ... ) => string');
+  });
+
+  it('should return () => returnsType when there is only a @returns', () => {
+    const { params, returns } = parseJsDoc('@returns {string}').extractedTags;
+    const result = generateShortFuncSignature(params, returns);
+
+    expect(result).toBe('() => string');
+  });
+});

--- a/addons/docs/src/frameworks/preact/propTypes/generateFuncSignature.ts
+++ b/addons/docs/src/frameworks/preact/propTypes/generateFuncSignature.ts
@@ -1,0 +1,68 @@
+import { ExtractedJsDocParam, ExtractedJsDocReturns } from '../../../lib/jsdocParser';
+
+export function generateFuncSignature(
+  params: ExtractedJsDocParam[],
+  returns: ExtractedJsDocReturns
+): string {
+  const hasParams = params != null;
+  const hasReturns = returns != null;
+
+  if (!hasParams && !hasReturns) {
+    return '';
+  }
+
+  const funcParts = [];
+
+  if (hasParams) {
+    const funcParams = params.map((x: ExtractedJsDocParam) => {
+      const prettyName = x.getPrettyName();
+      const typeName = x.getTypeName();
+
+      if (typeName != null) {
+        return `${prettyName}: ${typeName}`;
+      }
+
+      return prettyName;
+    });
+
+    funcParts.push(`(${funcParams.join(', ')})`);
+  } else {
+    funcParts.push('()');
+  }
+
+  if (hasReturns) {
+    funcParts.push(`=> ${returns.getTypeName()}`);
+  }
+
+  return funcParts.join(' ');
+}
+
+export function generateShortFuncSignature(
+  params: ExtractedJsDocParam[],
+  returns: ExtractedJsDocReturns
+): string {
+  const hasParams = params != null;
+  const hasReturns = returns != null;
+
+  if (!hasParams && !hasReturns) {
+    return '';
+  }
+
+  const funcParts = [];
+
+  if (hasParams) {
+    funcParts.push('( ... )');
+  } else {
+    funcParts.push('()');
+  }
+
+  if (hasReturns) {
+    funcParts.push(`=> ${returns.getTypeName()}`);
+  }
+
+  return funcParts.join(' ');
+}
+
+export function toMultilineSignature(signature: string): string {
+  return signature.replace(/,/g, ',\r\n');
+}

--- a/addons/docs/src/frameworks/preact/propTypes/handleProp.test.tsx
+++ b/addons/docs/src/frameworks/preact/propTypes/handleProp.test.tsx
@@ -1,0 +1,1480 @@
+/* eslint-disable no-underscore-dangle */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Component } from '../../../blocks/types';
+import {
+  PropDef,
+  extractComponentProps,
+  DocgenInfo,
+  DocgenPropDefaultValue,
+} from '../../../lib/docgen';
+import { enhancePropTypesProp, enhancePropTypesProps } from './handleProp';
+
+const DOCGEN_SECTION = 'props';
+
+function ReactComponent() {
+  return <div>React Component!</div>;
+}
+
+function createDocgenSection(docgenInfo: DocgenInfo): Record<string, any> {
+  return {
+    [DOCGEN_SECTION]: {
+      ...docgenInfo,
+    },
+  };
+}
+
+function createDocgenProp({
+  name,
+  type,
+  ...others
+}: Partial<DocgenInfo> & { name: string }): Record<string, any> {
+  return {
+    [name]: {
+      type,
+      required: false,
+      ...others,
+    },
+  };
+}
+
+// eslint-disable-next-line react/forbid-foreign-prop-types
+function createComponent({ propTypes = {}, defaultProps = {}, docgenInfo = {} }): Component {
+  const component = () => {
+    return <div>Hey!</div>;
+  };
+  component.propTypes = propTypes;
+  component.defaultProps = defaultProps;
+
+  // @ts-ignore
+  component.__docgenInfo = createDocgenSection(docgenInfo);
+
+  return component;
+}
+
+function createDefaultValue(defaultValue: string): DocgenPropDefaultValue {
+  return { value: defaultValue };
+}
+
+function extractPropDef(component: Component, rawDefaultProp?: any): PropDef {
+  return enhancePropTypesProp(extractComponentProps(component, DOCGEN_SECTION)[0], rawDefaultProp);
+}
+
+describe('enhancePropTypesProp', () => {
+  describe('type', () => {
+    function createTestComponent(docgenInfo: Partial<DocgenInfo>): Component {
+      return createComponent({
+        docgenInfo: {
+          ...createDocgenProp({ name: 'prop', ...docgenInfo }),
+        },
+      });
+    }
+
+    describe('custom', () => {
+      describe('when raw value is available', () => {
+        it('should support literal', () => {
+          const component = createTestComponent({
+            type: {
+              name: 'custom',
+              raw: 'MY_LITERAL',
+            },
+          });
+
+          const { type } = extractPropDef(component);
+
+          expect(type.summary).toBe('MY_LITERAL');
+          expect(type.detail).toBeUndefined();
+        });
+
+        it('should support short object', () => {
+          const component = createTestComponent({
+            type: {
+              name: 'custom',
+              raw: '{\n  text: PropTypes.string.isRequired,\n}',
+            },
+          });
+
+          const { type } = extractPropDef(component);
+
+          const expectedSummary = '{ text: string }';
+
+          expect(type.summary.replace(/\s/g, '')).toBe(expectedSummary.replace(/\s/g, ''));
+          expect(type.detail).toBeUndefined();
+        });
+
+        it('should support long object', () => {
+          const component = createTestComponent({
+            type: {
+              name: 'custom',
+              raw:
+                '{\n  text: PropTypes.string.isRequired,\n  value1: PropTypes.string.isRequired,\n  value2: PropTypes.string.isRequired,\n  value3: PropTypes.string.isRequired,\n  value4: PropTypes.string.isRequired,\n}',
+            },
+          });
+
+          const { type } = extractPropDef(component);
+
+          expect(type.summary).toBe('object');
+
+          const expectedDetail = `{
+            text: string,
+            value1: string,
+            value2: string,
+            value3: string,
+            value4: string
+          }`;
+
+          expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+        });
+
+        it('should not have a deep object as summary', () => {
+          const component = createTestComponent({
+            type: {
+              name: 'custom',
+              raw: '{\n  foo: { bar: PropTypes.string.isRequired,\n  }}',
+            },
+          });
+
+          const { type } = extractPropDef(component);
+
+          expect(type.summary).toBe('object');
+        });
+
+        it('should use identifier of a React element when available', () => {
+          const component = createTestComponent({
+            type: {
+              name: 'custom',
+              raw:
+                'function InlinedFunctionalComponent() {\n  return <div>Inlined FunctionalComponent!</div>;\n}',
+            },
+          });
+
+          const { type } = extractPropDef(component);
+
+          expect(type.summary).toBe('InlinedFunctionalComponent');
+
+          const expectedDetail = `function InlinedFunctionalComponent() {
+            return <div>Inlined FunctionalComponent!</div>;
+          }`;
+
+          expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+        });
+
+        it('should not use identifier of a HTML element', () => {
+          const component = createTestComponent({
+            type: {
+              name: 'custom',
+              raw:
+                '<div>Hello world from Montreal, Quebec, Canada!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</div>',
+            },
+          });
+
+          const { type } = extractPropDef(component);
+
+          expect(type.summary).toBe('element');
+
+          const expectedDetail =
+            '<div>Hello world from Montreal, Quebec, Canada!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</div>';
+
+          expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+        });
+
+        it('should support element without identifier', () => {
+          const component = createTestComponent({
+            type: {
+              name: 'custom',
+              raw: '() => {\n  return <div>Inlined FunctionalComponent!</div>;\n}',
+            },
+          });
+
+          const { type } = extractPropDef(component);
+
+          expect(type.summary).toBe('element');
+
+          const expectedDetail = `() => {
+              return <div>Inlined FunctionalComponent!</div>;
+            }`;
+
+          expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+        });
+
+        describe('when it is not a known type', () => {
+          it('should return "custom" when its a long type', () => {
+            const component = createTestComponent({
+              type: {
+                name: 'custom',
+                raw:
+                  'Symbol("A very very very very very very lonnnngggggggggggggggggggggggggggggggggggg symbol")',
+              },
+            });
+
+            const { type } = extractPropDef(component);
+
+            expect(type.summary).toBe('custom');
+            expect(type.detail).toBe(
+              'Symbol("A very very very very very very lonnnngggggggggggggggggggggggggggggggggggg symbol")'
+            );
+          });
+
+          it('should return "custom" when its a short type', () => {
+            const component = createTestComponent({
+              type: {
+                name: 'custom',
+                raw: 'Symbol("Hey!")',
+              },
+            });
+
+            const { type } = extractPropDef(component);
+
+            expect(type.summary).toBe('Symbol("Hey!")');
+            expect(type.detail).toBeUndefined();
+          });
+        });
+      });
+
+      it("should return 'custom' when there is no raw value", () => {
+        const component = createTestComponent({
+          type: {
+            name: 'custom',
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('custom');
+      });
+    });
+
+    [
+      'any',
+      'bool',
+      'string',
+      'number',
+      'symbol',
+      'object',
+      'element',
+      'elementType',
+      'node',
+    ].forEach((x) => {
+      it(`should return '${x}' when type is ${x}`, () => {
+        const component = createTestComponent({
+          type: {
+            name: x,
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe(x);
+      });
+    });
+
+    it('should support short shape', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'shape',
+          value: {
+            foo: {
+              name: 'string',
+              required: false,
+            },
+          },
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      const expectedSummary = '{ foo: string }';
+
+      expect(type.summary.replace(/\s/g, '')).toBe(expectedSummary.replace(/\s/g, ''));
+      expect(type.detail).toBeUndefined();
+    });
+
+    it('should support long shape', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'shape',
+          value: {
+            foo: {
+              name: 'string',
+              required: false,
+            },
+            bar: {
+              name: 'string',
+              required: false,
+            },
+            another: {
+              name: 'string',
+              required: false,
+            },
+            another2: {
+              name: 'string',
+              required: false,
+            },
+            another3: {
+              name: 'string',
+              required: false,
+            },
+            another4: {
+              name: 'string',
+              required: false,
+            },
+          },
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe('object');
+
+      const expectedDetail = `{
+        foo: string,
+        bar: string,
+        another: string,
+        another2: string,
+        another3: string,
+        another4: string
+      }`;
+
+      expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should not have a deep shape as summary', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'shape',
+          value: {
+            bar: {
+              name: 'shape',
+              value: {
+                hey: {
+                  name: 'string',
+                  required: false,
+                },
+              },
+              required: false,
+            },
+          },
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe('object');
+    });
+
+    it('should support enum of string', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'enum',
+          value: [
+            {
+              value: "'News'",
+              computed: false,
+            },
+            {
+              value: "'Photos'",
+              computed: false,
+            },
+          ],
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe("'News' | 'Photos'");
+    });
+
+    it('should support enum of object', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'enum',
+          value: [
+            {
+              value:
+                '{\n  text: PropTypes.string.isRequired,\n  value: PropTypes.string.isRequired,\n}',
+              computed: true,
+            },
+            {
+              value:
+                '{\n  foo: PropTypes.string,\n  bar: PropTypes.string,\n  hey: PropTypes.string,\n  ho: PropTypes.string,\n}',
+              computed: true,
+            },
+          ],
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe('object | object');
+
+      const expectedDetail = `{
+          text: string,
+          value: string
+        } | {
+          foo: string,
+          bar: string,
+          hey: string,
+          ho: string
+        }`;
+
+      expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should support short object in enum summary', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'enum',
+          value: [
+            {
+              value: '{\n  text: PropTypes.string.isRequired,\n}',
+              computed: true,
+            },
+            {
+              value: '{\n  foo: PropTypes.string,\n}',
+              computed: true,
+            },
+          ],
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe('{ text: string } | { foo: string }');
+    });
+
+    it('should not have a deep object in an enum summary', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'enum',
+          value: [
+            {
+              value: '{\n  text: { foo: PropTypes.string.isRequired,\n }\n}',
+              computed: true,
+            },
+            {
+              value: '{\n  foo: PropTypes.string,\n}',
+              computed: true,
+            },
+          ],
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe('object | object');
+    });
+
+    it('should support enum of element', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'enum',
+          value: [
+            {
+              value: '() => {\n  return <div>FunctionalComponent!</div>;\n}',
+              computed: true,
+            },
+            {
+              value:
+                'class ClassComponent extends React.PureComponent {\n  render() {\n    return <div>ClassComponent!</div>;\n  }\n}',
+              computed: true,
+            },
+          ],
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe('element | ClassComponent');
+
+      const expectedDetail = `() => {
+          return <div>FunctionalComponent!</div>;
+        } | class ClassComponent extends React.PureComponent {
+          render() {
+            return <div>ClassComponent!</div>;
+          }
+        }`;
+
+      expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    describe('func', () => {
+      it('should return "func" when the prop dont have a description', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'func',
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('func');
+      });
+
+      it('should return "func" when the prop have a description without JSDoc tags', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'func',
+          },
+          description: 'Hey! Hey!',
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('func');
+      });
+
+      it('should return a func signature when there is JSDoc tags.', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'func',
+          },
+          description: '@param event\n@param data\n@returns {string}',
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('(event, data) => string');
+      });
+    });
+
+    it('should return the instance type when type is instanceOf', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'instanceOf',
+          value: 'Set',
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe('Set');
+    });
+
+    describe('objectOf', () => {
+      it('should support objectOf primitive', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'objectOf',
+            value: {
+              name: 'number',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('objectOf(number)');
+        expect(type.detail).toBeUndefined();
+      });
+
+      it('should support objectOf of identifier', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'objectOf',
+            value: {
+              name: 'custom',
+              raw: 'NAMED_OBJECT',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('objectOf(NAMED_OBJECT)');
+        expect(type.detail).toBeUndefined();
+      });
+
+      it('should support objectOf short object', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'objectOf',
+            value: {
+              name: 'custom',
+              raw: '{\n  foo: PropTypes.string,\n}',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('objectOf({ foo: string })');
+        expect(type.detail).toBeUndefined();
+      });
+
+      it('should support objectOf long object', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'objectOf',
+            value: {
+              name: 'custom',
+              raw:
+                '{\n  foo: PropTypes.string,\n  bar: PropTypes.string,\n  another: PropTypes.string,\n  anotherAnother: PropTypes.string,\n}',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('objectOf(object)');
+
+        const expectedDetail = `objectOf({
+          foo: string,
+          bar: string,
+          another: string,
+          anotherAnother: string
+        })`;
+
+        expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      it('should not have deep object in summary', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'objectOf',
+            value: {
+              name: 'custom',
+              raw: '{\n  foo: { bar: PropTypes.string,\n }\n}',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('objectOf(object)');
+      });
+
+      it('should support objectOf short shape', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'objectOf',
+            value: {
+              name: 'shape',
+              value: {
+                foo: {
+                  name: 'string',
+                  required: false,
+                },
+              },
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('objectOf({ foo: string })');
+        expect(type.detail).toBeUndefined();
+      });
+
+      it('should support objectOf long shape', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'objectOf',
+            value: {
+              name: 'shape',
+              value: {
+                foo: {
+                  name: 'string',
+                  required: false,
+                },
+                bar: {
+                  name: 'string',
+                  required: false,
+                },
+                another: {
+                  name: 'string',
+                  required: false,
+                },
+                anotherAnother: {
+                  name: 'string',
+                  required: false,
+                },
+              },
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('objectOf(object)');
+
+        const expectedDetail = `objectOf({
+          foo: string,
+          bar: string,
+          another: string,
+          anotherAnother: string
+        })`;
+
+        expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      it('should not have a deep shape in summary', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'objectOf',
+            value: {
+              name: 'shape',
+              value: {
+                bar: {
+                  name: 'shape',
+                  value: {
+                    hey: {
+                      name: 'string',
+                      required: false,
+                    },
+                  },
+                  required: false,
+                },
+              },
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('objectOf(object)');
+      });
+    });
+
+    it('should support union', () => {
+      const component = createTestComponent({
+        type: {
+          name: 'union',
+          value: [
+            {
+              name: 'string',
+            },
+            {
+              name: 'instanceOf',
+              value: 'Set',
+            },
+          ],
+        },
+      });
+
+      const { type } = extractPropDef(component);
+
+      expect(type.summary).toBe('string | Set');
+      expect(type.detail).toBeUndefined();
+    });
+
+    describe('array', () => {
+      it('should support array of primitive', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'arrayOf',
+            value: {
+              name: 'number',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('number[]');
+        expect(type.detail).toBeUndefined();
+      });
+
+      it('should support array of identifier', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'arrayOf',
+            value: {
+              name: 'custom',
+              raw: 'NAMED_OBJECT',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('NAMED_OBJECT[]');
+        expect(type.detail).toBeUndefined();
+      });
+
+      it('should support array of short object', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'arrayOf',
+            value: {
+              name: 'custom',
+              raw: '{\n  foo: PropTypes.string,\n}',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('[{ foo: string }]');
+        expect(type.detail).toBeUndefined();
+      });
+
+      it('should support array of long object', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'arrayOf',
+            value: {
+              name: 'custom',
+              raw:
+                '{\n  text: PropTypes.string.isRequired,\n  value: PropTypes.string.isRequired,\n  another: PropTypes.string.isRequired,\n  another2: PropTypes.string.isRequired,\n  another3: PropTypes.string.isRequired,\n  another4: PropTypes.string.isRequired,\n}',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('object[]');
+
+        const expectedDetail = `[{
+          text: string,
+          value: string,
+          another: string,
+          another2: string,
+          another3: string,
+          another4: string
+        }]`;
+
+        expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      it('should not have deep object in summary', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'arrayOf',
+            value: {
+              name: 'custom',
+              raw: '{\n  foo: { bar: PropTypes.string, }\n}',
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('object[]');
+      });
+
+      it('should support array of short shape', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'arrayOf',
+            value: {
+              name: 'shape',
+              value: {
+                foo: {
+                  name: 'string',
+                  required: false,
+                },
+              },
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('[{ foo: string }]');
+        expect(type.detail).toBeUndefined();
+      });
+
+      it('should support array of long shape', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'arrayOf',
+            value: {
+              name: 'shape',
+              value: {
+                foo: {
+                  name: 'string',
+                  required: false,
+                },
+                bar: {
+                  name: 'string',
+                  required: false,
+                },
+                another: {
+                  name: 'string',
+                  required: false,
+                },
+                another2: {
+                  name: 'string',
+                  required: false,
+                },
+                another3: {
+                  name: 'string',
+                  required: false,
+                },
+                another4: {
+                  name: 'string',
+                  required: false,
+                },
+              },
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('object[]');
+
+        const expectedDetail = `[{
+          foo: string,
+          bar: string,
+          another: string,
+          another2: string,
+          another3: string,
+          another4: string
+        }]`;
+
+        expect(type.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      it('should not have deep shape in summary', () => {
+        const component = createTestComponent({
+          type: {
+            name: 'arrayOf',
+            value: {
+              name: 'shape',
+              value: {
+                bar: {
+                  name: 'shape',
+                  value: {
+                    hey: {
+                      name: 'string',
+                      required: false,
+                    },
+                  },
+                  required: false,
+                },
+              },
+            },
+          },
+        });
+
+        const { type } = extractPropDef(component);
+
+        expect(type.summary).toBe('object[]');
+      });
+    });
+  });
+
+  describe('defaultValue', () => {
+    function createTestComponent(
+      defaultValue: DocgenPropDefaultValue,
+      typeName = 'anything-is-fine'
+    ): Component {
+      return createComponent({
+        docgenInfo: {
+          ...createDocgenProp({
+            name: 'prop',
+            type: { name: typeName },
+            defaultValue,
+          }),
+        },
+      });
+    }
+
+    it('should support short object', () => {
+      const component = createTestComponent(createDefaultValue("{ foo: 'foo', bar: 'bar' }"));
+
+      const { defaultValue } = extractPropDef(component);
+
+      const expectedSummary = "{ foo: 'foo', bar: 'bar' }";
+
+      expect(defaultValue.summary.replace(/\s/g, '')).toBe(expectedSummary.replace(/\s/g, ''));
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long object', () => {
+      const component = createTestComponent(
+        createDefaultValue("{ foo: 'foo', bar: 'bar', another: 'another' }")
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('object');
+
+      const expectedDetail = `{
+        foo: 'foo',
+        bar: 'bar',
+        another: 'another'
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should not have deep object in summary', () => {
+      const component = createTestComponent(
+        createDefaultValue("{ foo: 'foo', bar: { hey: 'ho' } }")
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('object');
+    });
+
+    it('should support short function', () => {
+      const component = createTestComponent(createDefaultValue('() => {}'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('() => {}');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long function', () => {
+      const component = createTestComponent(
+        createDefaultValue(
+          '(foo, bar) => {\n  const concat = foo + bar;\n  const append = concat + " hey!";\n  \n  return append;\n}'
+        )
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('func');
+
+      const expectedDetail = `(foo, bar) => {
+        const concat = foo + bar;
+        const append = concat + ' hey!';
+        return append
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should use the name of function when available and indicate that args are present', () => {
+      const component = createTestComponent(
+        createDefaultValue('function concat(a, b) {\n  return a + b;\n}')
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('concat( ... )');
+
+      const expectedDetail = `function concat(a, b) {
+        return a + b
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should use the name of function when available', () => {
+      const component = createTestComponent(
+        createDefaultValue('function hello() {\n  return "hello";\n}')
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('hello()');
+
+      const expectedDetail = `function hello() {
+        return 'hello'
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should support short element', () => {
+      const component = createTestComponent(createDefaultValue('<div>Hey!</div>'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('<div>Hey!</div>');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long element', () => {
+      const component = createTestComponent(
+        createDefaultValue(
+          '<div>Hey! Hey! Hey!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</div>'
+        )
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('element');
+      expect(defaultValue.detail).toBe(
+        '<div>Hey! Hey! Hey!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</div>'
+      );
+    });
+
+    it('should support element with props', () => {
+      const component = createTestComponent(createDefaultValue('<Component className="toto" />'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('<Component />');
+      expect(defaultValue.detail).toBe('<Component className="toto" />');
+    });
+
+    it("should use the name of the React component when it's available", () => {
+      const component = createTestComponent(
+        createDefaultValue(
+          'function InlinedFunctionalComponent() {\n  return <div>Inlined FunctionalComponent!</div>;\n}'
+        )
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('<InlinedFunctionalComponent />');
+
+      const expectedDetail = `function InlinedFunctionalComponent() {
+        return <div>Inlined FunctionalComponent!</div>;
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should not use the name of an HTML element', () => {
+      const component = createTestComponent(createDefaultValue('<div>Hey!</div>'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).not.toBe('<div />');
+    });
+
+    it('should support short array', () => {
+      const component = createTestComponent(createDefaultValue('[1]'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('[1]');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long array', () => {
+      const component = createTestComponent(
+        createDefaultValue(
+          '[\n  {\n    thing: {\n      id: 2,\n      func: () => {},\n      arr: [],\n    },\n  },\n]'
+        )
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('array');
+
+      const expectedDetail = `[{
+          thing: {
+            id: 2,
+            func: () => {
+            },
+            arr: []
+          }
+        }]`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should not have deep array in summary', () => {
+      const component = createTestComponent(createDefaultValue('[[[1]]]'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('array');
+    });
+
+    describe('fromRawDefaultProp', () => {
+      [
+        { type: 'number', defaultProp: 1 },
+        { type: 'boolean', defaultProp: true },
+        { type: 'symbol', defaultProp: Symbol('hey!') },
+      ].forEach((x) => {
+        it(`should support ${x.type}`, () => {
+          const component = createTestComponent(null);
+
+          const { defaultValue } = extractPropDef(component, x.defaultProp);
+
+          expect(defaultValue.summary).toBe(x.defaultProp.toString());
+          expect(defaultValue.detail).toBeUndefined();
+        });
+      });
+
+      it('should support strings', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, 'foo');
+
+        expect(defaultValue.summary).toBe('"foo"');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support array of primitives', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, [1, 2, 3]);
+
+        expect(defaultValue.summary).toBe('[1,    2,    3]');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support array of short object', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, [{ foo: 'bar' }]);
+
+        expect(defaultValue.summary).toBe("[{ 'foo': 'bar' }]");
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support array of long object', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, [{ foo: 'bar', bar: 'foo', hey: 'ho' }]);
+
+        expect(defaultValue.summary).toBe('array');
+
+        const expectedDetail = `[{
+          'foo': 'bar',
+          'bar': 'foo',
+          'hey': 'ho'
+        }]`;
+
+        expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      it('should support short object', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, { foo: 'bar' });
+
+        expect(defaultValue.summary).toBe("{ 'foo': 'bar' }");
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support long object', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, { foo: 'bar', bar: 'foo', hey: 'ho' });
+
+        expect(defaultValue.summary).toBe('object');
+
+        const expectedDetail = `{
+          'foo': 'bar',
+          'bar': 'foo',
+          'hey': 'ho'
+        }`;
+
+        expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      it('should support anonymous function', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, () => 'hey!');
+
+        expect(defaultValue.summary).toBe('func');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support named function', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, function hello() {
+          return 'world!';
+        });
+
+        expect(defaultValue.summary).toBe('hello()');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support named function with params', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, function add(a: number, b: number) {
+          return a + b;
+        });
+
+        expect(defaultValue.summary).toBe('add( ... )');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support React element', () => {
+        const component = createTestComponent(null);
+
+        const defaultProp = <ReactComponent />;
+        // Simulate babel-plugin-add-react-displayname.
+        defaultProp.type.displayName = 'ReactComponent';
+
+        const { defaultValue } = extractPropDef(component, defaultProp);
+
+        expect(defaultValue.summary).toBe('<ReactComponent />');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support React element with props', () => {
+        const component = createTestComponent(null);
+
+        // @ts-ignore
+        const defaultProp = <ReactComponent className="toto" />;
+        // Simulate babel-plugin-add-react-displayname.
+        defaultProp.type.displayName = 'ReactComponent';
+
+        const { defaultValue } = extractPropDef(component, defaultProp);
+
+        expect(defaultValue.summary).toBe('<ReactComponent />');
+        expect(defaultValue.detail).toBe('<ReactComponent className="toto" />');
+      });
+
+      it('should support short HTML element', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, <div>HTML element</div>);
+
+        expect(defaultValue.summary).toBe('<div>HTML element</div>');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support long HTML element', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(
+          component,
+          <div>HTML element!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</div>
+        );
+
+        expect(defaultValue.summary).toBe('element');
+
+        const expectedDetail = `<div>
+          HTML element!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        </div>`;
+
+        expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      ['element', 'elementType'].forEach((x) => {
+        it(`should support inlined React class component for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(
+            component,
+            class InlinedClassComponent extends React.PureComponent {
+              render() {
+                return <div>Inlined ClassComponent!</div>;
+              }
+            }
+          );
+
+          expect(defaultValue.summary).toBe('<InlinedClassComponent />');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+
+        it(`should support inlined anonymous React functional component for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(component, () => {
+            return <div>Inlined FunctionalComponent!</div>;
+          });
+
+          expect(defaultValue.summary).toBe('element');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+
+        it(`should support inlined anonymous React functional component with props for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(component, ({ foo }: { foo: string }) => {
+            return <div>{foo}</div>;
+          });
+
+          expect(defaultValue.summary).toBe('element');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+
+        it(`should support inlined named React functional component for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(component, function InlinedFunctionalComponent() {
+            return <div>Inlined FunctionalComponent!</div>;
+          });
+
+          expect(defaultValue.summary).toBe('<InlinedFunctionalComponent />');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+
+        it(`should support inlined named React functional component with props for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(
+            component,
+            function InlinedFunctionalComponent({ foo }: { foo: string }) {
+              return <div>{foo}</div>;
+            }
+          );
+
+          expect(defaultValue.summary).toBe('<InlinedFunctionalComponent />');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+      });
+    });
+  });
+});
+
+describe('enhancePropTypesProps', () => {
+  it('should keep the original definition order', () => {
+    const component = createComponent({
+      propTypes: {
+        foo: PropTypes.string,
+        middleWithDefaultValue: PropTypes.string,
+        bar: PropTypes.string,
+        endWithDefaultValue: PropTypes.string,
+      },
+      docgenInfo: {
+        ...createDocgenProp({
+          name: 'middleWithDefaultValue',
+          type: { name: 'string' },
+          defaultValue: { value: 'Middle!' },
+        }),
+        ...createDocgenProp({
+          name: 'endWithDefaultValue',
+          type: { name: 'string' },
+          defaultValue: { value: 'End!' },
+        }),
+        ...createDocgenProp({
+          name: 'foo',
+          type: { name: 'string' },
+        }),
+        ...createDocgenProp({
+          name: 'bar',
+          type: { name: 'string' },
+        }),
+      },
+    });
+
+    const props = enhancePropTypesProps(
+      extractComponentProps(component, DOCGEN_SECTION),
+      component
+    );
+
+    expect(props.length).toBe(4);
+    expect(props[0].name).toBe('foo');
+    expect(props[1].name).toBe('middleWithDefaultValue');
+    expect(props[2].name).toBe('bar');
+    expect(props[3].name).toBe('endWithDefaultValue');
+  });
+
+  it('should not include @ignore props', () => {
+    const component = createComponent({
+      propTypes: {
+        foo: PropTypes.string,
+        bar: PropTypes.string,
+      },
+      docgenInfo: {
+        ...createDocgenProp({
+          name: 'foo',
+          type: { name: 'string' },
+        }),
+        ...createDocgenProp({
+          name: 'bar',
+          type: { name: 'string' },
+          description: '@ignore',
+        }),
+      },
+    });
+
+    const props = enhancePropTypesProps(
+      extractComponentProps(component, DOCGEN_SECTION),
+      component
+    );
+
+    expect(props.length).toBe(1);
+    expect(props[0].name).toBe('foo');
+  });
+});

--- a/addons/docs/src/frameworks/preact/propTypes/handleProp.ts
+++ b/addons/docs/src/frameworks/preact/propTypes/handleProp.ts
@@ -1,0 +1,48 @@
+import { PropDef, ExtractedProp } from '../../../lib/docgen';
+import { createType } from './createType';
+import { createDefaultValue, createDefaultValueFromRawDefaultProp } from '../lib/defaultValues';
+import { Component } from '../../../blocks/types';
+import { keepOriginalDefinitionOrder } from './sortProps';
+import { rawDefaultPropTypeResolvers } from './rawDefaultPropResolvers';
+
+export function enhancePropTypesProp(extractedProp: ExtractedProp, rawDefaultProp?: any): PropDef {
+  const { propDef } = extractedProp;
+
+  const newtype = createType(extractedProp);
+  if (newtype != null) {
+    propDef.type = newtype;
+  }
+
+  const { defaultValue } = extractedProp.docgenInfo;
+  if (defaultValue != null && defaultValue.value != null) {
+    const newDefaultValue = createDefaultValue(defaultValue.value);
+
+    if (newDefaultValue != null) {
+      propDef.defaultValue = newDefaultValue;
+    }
+  } else if (rawDefaultProp != null) {
+    const newDefaultValue = createDefaultValueFromRawDefaultProp(
+      rawDefaultProp,
+      propDef,
+      rawDefaultPropTypeResolvers
+    );
+
+    if (newDefaultValue != null) {
+      propDef.defaultValue = newDefaultValue;
+    }
+  }
+
+  return propDef;
+}
+
+export function enhancePropTypesProps(
+  extractedProps: ExtractedProp[],
+  component: Component
+): PropDef[] {
+  const rawDefaultProps = component.defaultProps != null ? component.defaultProps : {};
+  const enhancedProps = extractedProps.map((x) =>
+    enhancePropTypesProp(x, rawDefaultProps[x.propDef.name])
+  );
+
+  return keepOriginalDefinitionOrder(enhancedProps, component);
+}

--- a/addons/docs/src/frameworks/preact/propTypes/rawDefaultPropResolvers.ts
+++ b/addons/docs/src/frameworks/preact/propTypes/rawDefaultPropResolvers.ts
@@ -1,0 +1,31 @@
+import { TypeResolver, extractFunctionName, createTypeResolvers } from '../lib/defaultValues';
+import { createSummaryValue } from '../../../lib';
+import { FUNCTION_CAPTION, ELEMENT_CAPTION } from '../lib';
+import {
+  getPrettyElementIdentifier,
+  getPrettyFuncIdentifier,
+} from '../lib/defaultValues/prettyIdentifier';
+import { inspectValue, InspectionFunction } from '../lib/inspection';
+
+const funcResolver: TypeResolver = (rawDefaultProp, { name, type }) => {
+  const isElement = type.summary === 'element' || type.summary === 'elementType';
+
+  const funcName = extractFunctionName(rawDefaultProp, name);
+  if (funcName != null) {
+    // Try to display the name of the component. The body of the component is omitted since the code has been transpiled.
+    if (isElement) {
+      return createSummaryValue(getPrettyElementIdentifier(funcName));
+    }
+
+    const { hasParams } = inspectValue(rawDefaultProp.toString())
+      .inferredType as InspectionFunction;
+
+    return createSummaryValue(getPrettyFuncIdentifier(funcName, hasParams));
+  }
+
+  return createSummaryValue(isElement ? ELEMENT_CAPTION : FUNCTION_CAPTION);
+};
+
+export const rawDefaultPropTypeResolvers = createTypeResolvers({
+  function: funcResolver,
+});

--- a/addons/docs/src/frameworks/preact/propTypes/sortProps.ts
+++ b/addons/docs/src/frameworks/preact/propTypes/sortProps.ts
@@ -1,0 +1,20 @@
+import { PropDef } from '../../../lib/docgen';
+import { Component } from '../../../blocks/types';
+
+// react-docgen doesn't returned the props in the order they were defined in the "propTypes" object of the component.
+// This function re-order them by their original definition order.
+export function keepOriginalDefinitionOrder(
+  extractedProps: PropDef[],
+  component: Component
+): PropDef[] {
+  // eslint-disable-next-line react/forbid-foreign-prop-types
+  const { propTypes } = component;
+
+  if (propTypes != null) {
+    return Object.keys(propTypes)
+      .map((x) => extractedProps.find((y) => y.name === x))
+      .filter((x) => x);
+  }
+
+  return extractedProps;
+}

--- a/addons/docs/src/frameworks/preact/react-argtypes.stories.tsx
+++ b/addons/docs/src/frameworks/preact/react-argtypes.stories.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import mapValues from 'lodash/mapValues';
+import { storiesOf, StoryContext } from '@storybook/react';
+import { ArgsTable } from '@storybook/components';
+import { Args } from '@storybook/api';
+import { inferControls } from '@storybook/client-api';
+
+import { extractArgTypes } from './extractArgTypes';
+import { Component } from '../../blocks';
+
+const argsTableProps = (component: Component) => {
+  const argTypes = extractArgTypes(component);
+  const parameters = { __isArgsStory: true };
+  const rows = inferControls(({ argTypes, parameters } as unknown) as StoryContext<any>);
+  return { rows };
+};
+
+const ArgsStory = ({ component }: any) => {
+  const { rows } = argsTableProps(component);
+  const initialArgs = mapValues(rows, (argType) => argType.defaultValue) as Args;
+
+  const [args, setArgs] = useState(initialArgs);
+  return (
+    <>
+      <p>
+        <b>NOTE:</b> these stories are to help visualise the snapshot tests in{' '}
+        <code>./react-properties.test.js</code>.
+      </p>
+      <ArgsTable rows={rows} args={args} updateArgs={(val) => setArgs({ ...args, ...val })} />
+      <table>
+        <thead>
+          <tr>
+            <th>arg name</th>
+            <th>argType</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(args).map(([key, val]) => (
+            <tr key={key}>
+              <td>
+                <code>{key}</code>
+              </td>
+              <td>
+                <pre>{JSON.stringify(rows[key])}</pre>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+};
+
+const typescriptFixtures = [
+  'aliases',
+  'arrays',
+  'enums',
+  'functions',
+  'interfaces',
+  'intersections',
+  'records',
+  'scalars',
+  'tuples',
+  'unions',
+  'optionals',
+];
+
+const typescriptStories = storiesOf('ArgTypes/TypeScript', module);
+typescriptFixtures.forEach((fixture) => {
+  // eslint-disable-next-line import/no-dynamic-require, global-require, no-shadow
+  const { Component } = require(`../../lib/convert/__testfixtures__/typescript/${fixture}`);
+  typescriptStories.add(fixture, () => <ArgsStory component={Component} />);
+});
+
+const proptypesFixtures = ['arrays', 'enums', 'misc', 'objects', 'react', 'scalars'];
+
+const proptypesStories = storiesOf('ArgTypes/PropTypes', module);
+proptypesFixtures.forEach((fixture) => {
+  // eslint-disable-next-line import/no-dynamic-require, global-require, no-shadow
+  const { Component } = require(`../../lib/convert/__testfixtures__/proptypes/${fixture}`);
+  proptypesStories.add(fixture, () => <ArgsStory component={Component} />);
+});
+
+const issuesFixtures = [
+  'js-class-component',
+  'js-function-component',
+  'js-function-component-inline-defaults',
+  'js-function-component-inline-defaults-no-propTypes',
+  'ts-function-component',
+  'ts-function-component-inline-defaults',
+  '9399-js-proptypes-shape',
+  '8663-js-styled-components',
+  '9626-js-default-values',
+  '9668-js-proptypes-no-jsdoc',
+  '8143-ts-react-fc-generics',
+  '8143-ts-imported-types',
+  '8279-js-styled-docgen',
+  '8140-js-prop-types-oneof',
+  '9023-js-hoc',
+  '8740-ts-multi-props',
+  '9556-ts-react-default-exports',
+  '9592-ts-styled-props',
+  '9591-ts-import-types',
+  '9721-ts-deprecated-jsdoc',
+  '9827-ts-default-values',
+  '9586-js-react-memo',
+  '9575-ts-camel-case',
+  '9493-ts-display-name',
+  '8894-9511-ts-forward-ref',
+  '9465-ts-type-props',
+  '8428-js-static-prop-types',
+  '9764-ts-extend-props',
+  '9922-ts-component-props',
+];
+
+const issuesStories = storiesOf('ArgTypes/Issues', module);
+issuesFixtures.forEach((fixture) => {
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  const { component } = require(`./__testfixtures__/${fixture}/input`);
+
+  issuesStories.add(fixture, () => <ArgsStory component={component} />, {
+    chromatic: { disable: true },
+  });
+});

--- a/addons/docs/src/frameworks/preact/react-properties.test.ts
+++ b/addons/docs/src/frameworks/preact/react-properties.test.ts
@@ -1,0 +1,83 @@
+import 'jest-specific-snapshot';
+import path from 'path';
+import fs from 'fs';
+
+import { transformFileSync, transformSync } from '@babel/core';
+import { inferControls } from '@storybook/store';
+import { StoryContext } from '@storybook/react';
+import { AnyFramework } from '@storybook/csf';
+import requireFromString from 'require-from-string';
+
+import { extractProps } from './extractProps';
+import { extractArgTypes } from './extractArgTypes';
+import { normalizeNewlines } from '../../lib/utils';
+
+// jest.mock('../imported', () => () => ({ imported: 'imported-value' }), { virtual: true });
+
+// File hierarchy:
+// __testfixtures__ / some-test-case / input.*
+const inputRegExp = /^input\..*$/;
+
+const transformToModule = (inputCode: string) => {
+  const options = {
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          targets: {
+            esmodules: true,
+          },
+        },
+      ],
+    ],
+  };
+  const { code } = transformSync(inputCode, options);
+  return normalizeNewlines(code);
+};
+
+const annotateWithDocgen = (inputPath: string) => {
+  const options = {
+    presets: ['@babel/typescript', '@babel/react'],
+    plugins: ['babel-plugin-react-docgen', '@babel/plugin-proposal-class-properties'],
+    babelrc: false,
+  };
+  const { code } = transformFileSync(inputPath, options);
+  return normalizeNewlines(code);
+};
+
+describe('react component properties', () => {
+  const fixturesDir = path.join(__dirname, '__testfixtures__');
+  fs.readdirSync(fixturesDir, { withFileTypes: true }).forEach((testEntry) => {
+    if (testEntry.isDirectory()) {
+      const testDir = path.join(fixturesDir, testEntry.name);
+      const testFile = fs.readdirSync(testDir).find((fileName) => inputRegExp.test(fileName));
+      if (testFile) {
+        // eslint-disable-next-line jest/valid-title
+        it(testEntry.name, () => {
+          const inputPath = path.join(testDir, testFile);
+
+          // snapshot the output of babel-plugin-react-docgen
+          const docgenPretty = annotateWithDocgen(inputPath);
+          expect(docgenPretty).toMatchSpecificSnapshot(path.join(testDir, 'docgen.snapshot'));
+
+          // transform into an uglier format that's works with require-from-string
+          const docgenModule = transformToModule(docgenPretty);
+
+          // snapshot the output of component-properties/react
+          const { component } = requireFromString(docgenModule, inputPath);
+          const properties = extractProps(component);
+          expect(properties).toMatchSpecificSnapshot(path.join(testDir, 'properties.snapshot'));
+
+          // snapshot the output of `extractArgTypes`
+          const argTypes = extractArgTypes(component);
+          const parameters = { __isArgsStory: true };
+          const rows = inferControls(({
+            argTypes,
+            parameters,
+          } as unknown) as StoryContext<AnyFramework>);
+          expect(rows).toMatchSpecificSnapshot(path.join(testDir, 'argTypes.snapshot'));
+        });
+      }
+    }
+  });
+});

--- a/addons/docs/src/frameworks/preact/typeScript/handleProp.test.tsx
+++ b/addons/docs/src/frameworks/preact/typeScript/handleProp.test.tsx
@@ -1,0 +1,513 @@
+/* eslint-disable no-underscore-dangle */
+
+import React from 'react';
+import { Component } from '../../../blocks/types';
+import {
+  PropDef,
+  extractComponentProps,
+  DocgenInfo,
+  DocgenPropDefaultValue,
+} from '../../../lib/docgen';
+import { enhanceTypeScriptProp } from './handleProp';
+
+const DOCGEN_SECTION = 'props';
+
+function ReactComponent() {
+  return <div>React Component!</div>;
+}
+
+function createDocgenSection(docgenInfo: DocgenInfo): Record<string, any> {
+  return {
+    [DOCGEN_SECTION]: {
+      ...docgenInfo,
+    },
+  };
+}
+
+function createDocgenProp({
+  name,
+  tsType,
+  ...others
+}: Partial<DocgenInfo> & { name: string }): Record<string, any> {
+  return {
+    [name]: {
+      tsType,
+      required: false,
+      ...others,
+    },
+  };
+}
+
+// eslint-disable-next-line react/forbid-foreign-prop-types
+function createComponent({ propTypes = {}, defaultProps = {}, docgenInfo = {} }): Component {
+  const component = () => {
+    return <div>Hey!</div>;
+  };
+  component.propTypes = propTypes;
+  component.defaultProps = defaultProps;
+
+  // @ts-ignore
+  component.__docgenInfo = createDocgenSection(docgenInfo);
+
+  return component;
+}
+
+function createDefaultValue(defaultValue: string): DocgenPropDefaultValue {
+  return { value: defaultValue };
+}
+
+function extractPropDef(component: Component, rawDefaultProp?: any): PropDef {
+  return enhanceTypeScriptProp(extractComponentProps(component, DOCGEN_SECTION)[0], rawDefaultProp);
+}
+
+describe('enhanceTypeScriptProp', () => {
+  describe('defaultValue', () => {
+    function createTestComponent(
+      defaultValue: DocgenPropDefaultValue,
+      typeName = 'anything-is-fine'
+    ): Component {
+      return createComponent({
+        docgenInfo: {
+          ...createDocgenProp({
+            name: 'prop',
+            tsType: { name: typeName },
+            defaultValue,
+          }),
+        },
+      });
+    }
+
+    it('should support short object', () => {
+      const component = createTestComponent(createDefaultValue("{ foo: 'foo', bar: 'bar' }"));
+
+      const { defaultValue } = extractPropDef(component);
+
+      const expectedSummary = "{ foo: 'foo', bar: 'bar' }";
+
+      expect(defaultValue.summary.replace(/\s/g, '')).toBe(expectedSummary.replace(/\s/g, ''));
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long object', () => {
+      const component = createTestComponent(
+        createDefaultValue("{ foo: 'foo', bar: 'bar', another: 'another' }")
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('object');
+
+      const expectedDetail = `{
+        foo: 'foo',
+        bar: 'bar',
+        another: 'another'
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should not have deep object in summary', () => {
+      const component = createTestComponent(
+        createDefaultValue("{ foo: 'foo', bar: { hey: 'ho' } }")
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('object');
+    });
+
+    it('should support short function', () => {
+      const component = createTestComponent(createDefaultValue('() => {}'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('() => {}');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long function', () => {
+      const component = createTestComponent(
+        createDefaultValue(
+          '(foo, bar) => {\n  const concat = foo + bar;\n  const append = concat + " hey!";\n  \n  return append;\n}'
+        )
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('func');
+
+      const expectedDetail = `(foo, bar) => {
+        const concat = foo + bar;
+        const append = concat + ' hey!';
+        return append
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should use the name of function when available and indicate that args are present', () => {
+      const component = createTestComponent(
+        createDefaultValue('function concat(a, b) {\n  return a + b;\n}')
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('concat( ... )');
+
+      const expectedDetail = `function concat(a, b) {
+        return a + b
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should use the name of function when available', () => {
+      const component = createTestComponent(
+        createDefaultValue('function hello() {\n  return "hello";\n}')
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('hello()');
+
+      const expectedDetail = `function hello() {
+        return 'hello'
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should support short element', () => {
+      const component = createTestComponent(createDefaultValue('<div>Hey!</div>'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('<div>Hey!</div>');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long element', () => {
+      const component = createTestComponent(
+        createDefaultValue(
+          '<div>Hey! Hey! Hey!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</div>'
+        )
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('element');
+      expect(defaultValue.detail).toBe(
+        '<div>Hey! Hey! Hey!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</div>'
+      );
+    });
+
+    it('should support element with props', () => {
+      const component = createTestComponent(createDefaultValue('<Component className="toto" />'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('<Component />');
+      expect(defaultValue.detail).toBe('<Component className="toto" />');
+    });
+
+    it("should use the name of the React component when it's available", () => {
+      const component = createTestComponent(
+        createDefaultValue(
+          'function InlinedFunctionalComponent() {\n  return <div>Inlined FunctionalComponent!</div>;\n}'
+        )
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('<InlinedFunctionalComponent />');
+
+      const expectedDetail = `function InlinedFunctionalComponent() {
+        return <div>Inlined FunctionalComponent!</div>;
+      }`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should not use the name of an HTML element', () => {
+      const component = createTestComponent(createDefaultValue('<div>Hey!</div>'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).not.toBe('<div />');
+    });
+
+    it('should support short array', () => {
+      const component = createTestComponent(createDefaultValue('[1]'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('[1]');
+      expect(defaultValue.detail).toBeUndefined();
+    });
+
+    it('should support long array', () => {
+      const component = createTestComponent(
+        createDefaultValue(
+          '[\n  {\n    thing: {\n      id: 2,\n      func: () => {},\n      arr: [],\n    },\n  },\n]'
+        )
+      );
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('array');
+
+      const expectedDetail = `[{
+          thing: {
+            id: 2,
+            func: () => {
+            },
+            arr: []
+          }
+        }]`;
+
+      expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+    });
+
+    it('should not have deep array in summary', () => {
+      const component = createTestComponent(createDefaultValue('[[[1]]]'));
+
+      const { defaultValue } = extractPropDef(component);
+
+      expect(defaultValue.summary).toBe('array');
+    });
+
+    describe('fromRawDefaultProp', () => {
+      [
+        { type: 'number', defaultProp: 1 },
+        { type: 'boolean', defaultProp: true },
+        { type: 'symbol', defaultProp: Symbol('hey!') },
+      ].forEach((x) => {
+        it(`should support ${x.type}`, () => {
+          const component = createTestComponent(null);
+
+          const { defaultValue } = extractPropDef(component, x.defaultProp);
+
+          expect(defaultValue.summary).toBe(x.defaultProp.toString());
+          expect(defaultValue.detail).toBeUndefined();
+        });
+      });
+
+      it('should support strings', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, 'foo');
+
+        expect(defaultValue.summary).toBe('"foo"');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support array of primitives', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, [1, 2, 3]);
+
+        expect(defaultValue.summary).toBe('[1,    2,    3]');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support array of short object', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, [{ foo: 'bar' }]);
+
+        expect(defaultValue.summary).toBe("[{ 'foo': 'bar' }]");
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support array of long object', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, [{ foo: 'bar', bar: 'foo', hey: 'ho' }]);
+
+        expect(defaultValue.summary).toBe('array');
+
+        const expectedDetail = `[{
+          'foo': 'bar',
+          'bar': 'foo',
+          'hey': 'ho'
+        }]`;
+
+        expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      it('should support short object', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, { foo: 'bar' });
+
+        expect(defaultValue.summary).toBe("{ 'foo': 'bar' }");
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support long object', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, { foo: 'bar', bar: 'foo', hey: 'ho' });
+
+        expect(defaultValue.summary).toBe('object');
+
+        const expectedDetail = `{
+          'foo': 'bar',
+          'bar': 'foo',
+          'hey': 'ho'
+        }`;
+
+        expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      it('should support anonymous function', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, () => 'hey!');
+
+        expect(defaultValue.summary).toBe('func');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support named function', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, function hello() {
+          return 'world!';
+        });
+
+        expect(defaultValue.summary).toBe('hello()');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support named function with params', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, function add(a: number, b: number) {
+          return a + b;
+        });
+
+        expect(defaultValue.summary).toBe('add( ... )');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support React element', () => {
+        const component = createTestComponent(null);
+
+        const defaultProp = <ReactComponent />;
+        // Simulate babel-plugin-add-react-displayname.
+        defaultProp.type.displayName = 'ReactComponent';
+
+        const { defaultValue } = extractPropDef(component, defaultProp);
+
+        expect(defaultValue.summary).toBe('<ReactComponent />');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support React element with props', () => {
+        const component = createTestComponent(null);
+
+        // @ts-ignore
+        const defaultProp = <ReactComponent className="toto" />;
+        // Simulate babel-plugin-add-react-displayname.
+        defaultProp.type.displayName = 'ReactComponent';
+
+        const { defaultValue } = extractPropDef(component, defaultProp);
+
+        expect(defaultValue.summary).toBe('<ReactComponent />');
+        expect(defaultValue.detail).toBe('<ReactComponent className="toto" />');
+      });
+
+      it('should support short HTML element', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(component, <div>HTML element</div>);
+
+        expect(defaultValue.summary).toBe('<div>HTML element</div>');
+        expect(defaultValue.detail).toBeUndefined();
+      });
+
+      it('should support long HTML element', () => {
+        const component = createTestComponent(null);
+
+        const { defaultValue } = extractPropDef(
+          component,
+          <div>HTML element!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</div>
+        );
+
+        expect(defaultValue.summary).toBe('element');
+
+        const expectedDetail = `<div>
+          HTML element!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        </div>`;
+
+        expect(defaultValue.detail.replace(/\s/g, '')).toBe(expectedDetail.replace(/\s/g, ''));
+      });
+
+      ['element', 'elementType'].forEach((x) => {
+        it(`should support inlined React class component for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(
+            component,
+            class InlinedClassComponent extends React.PureComponent {
+              render() {
+                return <div>Inlined ClassComponent!</div>;
+              }
+            }
+          );
+
+          expect(defaultValue.summary).toBe('<InlinedClassComponent />');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+
+        it(`should support inlined anonymous React functional component for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(component, () => {
+            return <div>Inlined FunctionalComponent!</div>;
+          });
+
+          expect(defaultValue.summary).toBe('element');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+
+        it(`should support inlined anonymous React functional component with props for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(component, ({ foo }: { foo: string }) => {
+            return <div>{foo}</div>;
+          });
+
+          expect(defaultValue.summary).toBe('element');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+
+        it(`should support inlined named React functional component for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(component, function InlinedFunctionalComponent() {
+            return <div>Inlined FunctionalComponent!</div>;
+          });
+
+          expect(defaultValue.summary).toBe('<InlinedFunctionalComponent />');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+
+        it(`should support inlined named React functional component with props for ${x}`, () => {
+          const component = createTestComponent(null, x);
+
+          const { defaultValue } = extractPropDef(
+            component,
+            function InlinedFunctionalComponent({ foo }: { foo: string }) {
+              return <div>{foo}</div>;
+            }
+          );
+
+          expect(defaultValue.summary).toBe('<InlinedFunctionalComponent />');
+          expect(defaultValue.detail).toBeUndefined();
+        });
+      });
+    });
+  });
+});

--- a/addons/docs/src/frameworks/preact/typeScript/handleProp.ts
+++ b/addons/docs/src/frameworks/preact/typeScript/handleProp.ts
@@ -1,0 +1,26 @@
+import { PropDef, ExtractedProp } from '../../../lib/docgen';
+import { createDefaultValue, createDefaultValueFromRawDefaultProp } from '../lib/defaultValues';
+
+export function enhanceTypeScriptProp(extractedProp: ExtractedProp, rawDefaultProp?: any): PropDef {
+  const { propDef } = extractedProp;
+
+  const { defaultValue } = extractedProp.docgenInfo;
+  if (defaultValue != null && defaultValue.value != null) {
+    const newDefaultValue = createDefaultValue(defaultValue.value);
+    if (newDefaultValue != null) {
+      propDef.defaultValue = newDefaultValue;
+    }
+  } else if (rawDefaultProp != null) {
+    const newDefaultValue = createDefaultValueFromRawDefaultProp(rawDefaultProp, propDef);
+
+    if (newDefaultValue != null) {
+      propDef.defaultValue = newDefaultValue;
+    }
+  }
+
+  return propDef;
+}
+
+export function enhanceTypeScriptProps(extractedProps: ExtractedProp[]): PropDef[] {
+  return extractedProps.map((prop) => enhanceTypeScriptProp(prop));
+}

--- a/app/preact/src/server/framework-preset-preact-docgen.ts
+++ b/app/preact/src/server/framework-preset-preact-docgen.ts
@@ -1,0 +1,53 @@
+import type { TransformOptions } from '@babel/core';
+import type { Configuration } from 'webpack';
+import ReactDocgenTypescriptPlugin from 'react-docgen-typescript-plugin';
+import type { Options, TypescriptConfig } from '@storybook/core-common';
+
+export async function babel(config: TransformOptions, { presets }: Options) {
+  const typescriptOptions = await presets.apply<TypescriptConfig>('typescript', {} as any);
+
+  const { reactDocgen } = typescriptOptions;
+
+  if (typeof reactDocgen !== 'string') {
+    return config;
+  }
+
+  return {
+    ...config,
+    overrides: [
+      {
+        test: reactDocgen === 'react-docgen' ? /\.(mjs|tsx?|jsx?)$/ : /\.(mjs|jsx?)$/,
+        plugins: [
+          [
+            require.resolve('babel-plugin-react-docgen'),
+            {
+              DOC_GEN_COLLECTION_NAME: 'STORYBOOK_REACT_CLASSES',
+            },
+          ],
+        ],
+      },
+    ],
+  };
+}
+
+export async function webpackFinal(config: Configuration, { presets }: Options) {
+  const typescriptOptions = await presets.apply<TypescriptConfig>('typescript', {} as any);
+
+  const { reactDocgen, reactDocgenTypescriptOptions } = typescriptOptions;
+
+  if (reactDocgen !== 'react-docgen-typescript') {
+    return config;
+  }
+
+  return {
+    ...config,
+    plugins: [
+      ...config.plugins,
+      new ReactDocgenTypescriptPlugin({
+        ...reactDocgenTypescriptOptions,
+        // We *need* this set so that RDT returns default values in the same format as react-docgen
+        savePropValueAsString: true,
+      }),
+    ],
+  };
+}

--- a/app/preact/src/server/options.ts
+++ b/app/preact/src/server/options.ts
@@ -4,5 +4,8 @@ import { LoadOptions } from '@storybook/core-common';
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,
   framework: 'preact',
-  frameworkPresets: [require.resolve('./framework-preset-preact.js')],
+  frameworkPresets: [
+    require.resolve('./framework-preset-preact.js'),
+    require.resolve('./framework-preset-preact-docgen.js'),
+  ],
 } as LoadOptions;

--- a/examples/preact-kitchen-sink/.storybook/main.js
+++ b/examples/preact-kitchen-sink/.storybook/main.js
@@ -12,6 +12,10 @@ module.exports = {
     '@storybook/addon-backgrounds',
     '@storybook/addon-a11y',
   ],
+  babel: async (options) => ({
+    ...options,
+    presets: [['@babel/typescript', { jsxPragma: 'h' }]],
+  }),
   webpackFinal: (config) => {
     config.module.rules.push({
       test: [/\.stories\.js$/],

--- a/examples/preact-kitchen-sink/src/HiddenMessage.tsx
+++ b/examples/preact-kitchen-sink/src/HiddenMessage.tsx
@@ -1,0 +1,27 @@
+import { h } from 'preact';
+import { useState } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
+
+export type PropsType = {
+  /**
+   * Child component to show or hide.
+   */
+  children: ComponentChildren;
+};
+function HiddenMessage({ children }: PropsType) {
+  const [showMessage, setShowMessage] = useState(false);
+  return (
+    <div>
+      <label htmlFor="toggle">Show Message</label>
+      <input
+        id="toggle"
+        type="checkbox"
+        onChange={(e) => setShowMessage((e.target as HTMLInputElement).checked)}
+        checked={showMessage}
+      />
+      {showMessage ? children : null}
+    </div>
+  );
+}
+
+export { HiddenMessage };

--- a/examples/preact-kitchen-sink/src/Preact.tsx
+++ b/examples/preact-kitchen-sink/src/Preact.tsx
@@ -1,0 +1,51 @@
+import { h, Component } from 'preact';
+import { useState } from 'preact/hooks';
+
+export type Props = {
+  /**
+   * Label property
+   */
+  label: string;
+};
+
+export function PreactFunctionalComponent({ label }: Props) {
+  const [clicks, setValue] = useState(0);
+  return (
+    <div
+      tabIndex={0}
+      onClick={() => setValue(clicks + 1)}
+      style={{ cursor: 'pointer' }}
+      onKeyDown={() => undefined}
+      role="button"
+    >
+      <div style={{ color: 'red' }}>{label}</div>
+      <div>Clicked {clicks} times.</div>
+    </div>
+  );
+};
+
+/**
+ * Pure preact based component sample.
+ */
+export class PreactClassComponent extends Component<Props> {
+  state = {
+    clicks: 0,
+  };
+
+  render() {
+    const { label } = this.props;
+    const { clicks } = this.state;
+    return (
+      <div
+        tabIndex={0}
+        onClick={() => this.setState({ clicks: clicks + 1 })}
+        onKeyDown={() => undefined}
+        style={{ cursor: 'pointer' }}
+        role="button"
+      >
+        <div style={{ color: 'green' }}>{label}</div>
+        <div>Clicked {clicks} times.</div>
+      </div>
+    );
+  }
+}

--- a/examples/preact-kitchen-sink/src/stories/hidden_message.stories.js
+++ b/examples/preact-kitchen-sink/src/stories/hidden_message.stories.js
@@ -1,0 +1,17 @@
+/** @jsx h */
+
+import { h } from 'preact';
+import { HiddenMessage } from '../HiddenMessage';
+
+export default {
+  component: HiddenMessage,
+  title: 'Hidden Message',
+};
+
+const Template = (args) => <HiddenMessage>{args.children}</HiddenMessage>;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  children: 'Hi from Storybook!',
+};

--- a/examples/preact-kitchen-sink/src/stories/preact.stories.js
+++ b/examples/preact-kitchen-sink/src/stories/preact.stories.js
@@ -1,0 +1,16 @@
+/** @jsx h */
+import { h } from 'preact';
+import { PreactFunctionalComponent, PreactClassComponent } from '../Preact';
+
+export default {
+  title: 'Pure Preact Components',
+};
+
+export const PreactComponentDemo = () => (
+  <div>
+    <h1>Preact component demo</h1>
+    <PreactFunctionalComponent label="This is a Preact functional component" />
+    <hr />
+    <PreactClassComponent label="This is a Preact class component" />
+  </div>
+);

--- a/examples/preact-kitchen-sink/tsconfig.json
+++ b/examples/preact-kitchen-sink/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "jsxFactory": "h",
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/*"]
+}


### PR DESCRIPTION
Issue:
Added preact framework entry for the docs addon also added a new story for the preact-kitchen-sink sample app.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
